### PR TITLE
refactor: remove ** abuse

### DIFF
--- a/mafic/errors.py
+++ b/mafic/errors.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from .typings import FriendlyException
+
 __all__ = (
     "LibraryCompatibilityError",
     "MaficException",
@@ -39,6 +46,10 @@ class MultipleCompatibleLibraries(LibraryCompatibilityError):
 class TrackLoadException(MaficException):
     def __init__(self, *, message: str, severity: str) -> None:
         super().__init__(f"The track could not be loaded: {message} ({severity} error)")
+
+    @classmethod
+    def from_data(cls, data: FriendlyException) -> Self:
+        return cls(message=data["message"], severity=data["severity"])
 
 
 class PlayerNotConnected(MaficException):

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -474,13 +474,13 @@ class Node:
         if data["loadType"] == "NO_MATCHES":
             return []
         elif data["loadType"] == "TRACK_LOADED":
-            return [Track.from_data(**data["tracks"][0])]
+            return [Track.from_data_with_info(data["tracks"][0])]
         elif data["loadType"] == "PLAYLIST_LOADED":
             return Playlist(info=data["playlistInfo"], tracks=data["tracks"])
         elif data["loadType"] == "SEARCH_RESULT":
-            return [Track.from_data(**track) for track in data["tracks"]]
+            return [Track.from_data_with_info(track) for track in data["tracks"]]
         elif data["loadType"] == "LOAD_FAILED":
-            raise TrackLoadException(**data["exception"])
+            raise TrackLoadException.from_data(data["exception"])
         else:
             _log.warning("Unknown load type recieved: %s", data["loadType"])
 
@@ -497,12 +497,12 @@ class Node:
             "POST", "/decodetracks", json=tracks
         )
 
-        return [Track.from_data(**track) for track in track_data]
+        return [Track.from_data_with_info(track) for track in track_data]
 
     async def fetch_plugins(self) -> list[Plugin]:
         plugins: list[PluginData] = await self.__request("GET", "/plugins")
 
-        return [Plugin(**plugins) for plugins in plugins]
+        return [Plugin.from_data(plugin) for plugin in plugins]
 
     async def fetch_route_planner_status(self) -> RoutePlannerStatus | None:
         data: RoutePlannerStatusPayload = await self.__request(

--- a/mafic/playlist.py
+++ b/mafic/playlist.py
@@ -18,4 +18,6 @@ class Playlist:
     def __init__(self, *, info: PlaylistInfo, tracks: list[TrackWithInfo]):
         self.name: str = info["name"]
         self.selected_track: int = info["selectedTrack"]
-        self.tracks: list[Track] = [Track.from_data(**track) for track in tracks]
+        self.tracks: list[Track] = [
+            Track.from_data_with_info(track) for track in tracks
+        ]

--- a/mafic/plugin.py
+++ b/mafic/plugin.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from .typings import PluginData
 
 
 @dataclass(repr=True)
 class Plugin:
     name: str
     version: str
+
+    @classmethod
+    def from_data(cls, data: PluginData) -> Self:
+        return cls(name=data["name"], version=data["version"])

--- a/mafic/track.py
+++ b/mafic/track.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from .typings import TrackInfo
+    from .typings import TrackInfo, TrackWithInfo
 
 __all__ = ("Track",)
 
@@ -57,7 +57,7 @@ class Track:
         self.length: int = length
 
     @classmethod
-    def from_data(cls, track: str, info: TrackInfo) -> Self:
+    def from_data(cls, *, track: str, info: TrackInfo) -> Self:
         return cls(
             track_id=track,
             title=info["title"],
@@ -70,3 +70,7 @@ class Track:
             position=info["position"],
             length=info["length"],
         )
+
+    @classmethod
+    def from_data_with_info(cls, data: TrackWithInfo) -> Self:
+        return cls.from_data(track=data["track"], info=data["info"])

--- a/mafic/typings/misc.py
+++ b/mafic/typings/misc.py
@@ -7,6 +7,7 @@ from typing import Any, Coroutine, Literal, TypedDict, TypeVar
 __all__ = (
     "Coro",
     "ExceptionSeverity",
+    "FriendlyException",
     "PayloadWithGuild",
 )
 T = TypeVar("T")


### PR DESCRIPTION
## Summary

Stops using `**` for passing data to classes, since adding fields is not a breaking change (lavalink v4).
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
