### PR TITLE
ci: lock pyright to 1.1.279

### DIFF
--- a/mafic/player.py
+++ b/mafic/player.py
@@ -168,8 +168,8 @@ class Player(VoiceProtocol):
         self_mute: bool = False,
         self_deaf: bool = False,
     ) -> None:
-        if not isinstance(self.channel, GuildChannel):
-            raise TypeError("Voice channel must be a GuildChannel.")
+        if not isinstance(self.channel, (VoiceChannel, StageChannel)):
+            raise TypeError("Voice channel must be a VoiceChannel or StageChannel.")
 
         _log.debug("Connecting to voice channel %s", self.channel.id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ aiohttp = "^3.6.0"
 orjson = {version = "^3.8.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
-pyright = "^1.1.270"
+pyright = "1.1.279"
 black = "^22.8.0"
 isort = "^5.10.1"
 taskipy = "^1.10.3"


### PR DESCRIPTION
## Summary

This PR locks pyright to a specific version. This means that CI will fail...controllably, instead of a change causing it to fail.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
