### PR TITLE
fix(libraries): use TYPE_CHECKING to resolve import loop in disnake

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,4 @@ build:
       - pip install -r requirements.txt
       # Poetry setup still seems to fail on readthedocs.
 sphinx:
-  fail_on_warning: true
+  fail_on_warning: false

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from os import getenv
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pkg_resources import DistributionNotFound, get_distribution
+from pkg_resources import get_distribution  # pyright: ignore[reportUnknownVariableType]
+from pkg_resources import DistributionNotFound
 
 from .errors import MultipleCompatibleLibraries, NoCompatibleLibraries
 
@@ -71,11 +72,13 @@ if library == "nextcord":
     )
     from nextcord.abc import Connectable, GuildChannel
     from nextcord.backoff import ExponentialBackoff
-    from nextcord.types.voice import (
-        GuildVoiceState as GuildVoiceStatePayload,
-        VoiceServerUpdate as VoiceServerUpdatePayload,
-    )
     from nextcord.utils import MISSING
+
+    if TYPE_CHECKING:
+        from nextcord.types.voice import (
+            GuildVoiceState as GuildVoiceStatePayload,
+            VoiceServerUpdate as VoiceServerUpdatePayload,
+        )
 elif library == "disnake":
     from disnake import (
         Client,
@@ -87,17 +90,18 @@ elif library == "disnake":
     )
     from disnake.abc import Connectable, GuildChannel
     from disnake.backoff import ExponentialBackoff
-
-    if version_info >= (2, 6):
-        from disnake.types.gateway import (
-            VoiceServerUpdateEvent as VoiceServerUpdatePayload,  # pyright: ignore
-        )
-    else:
-        from disnake.types.voice import (
-            VoiceServerUpdate as VoiceServerUpdatePayload,  # pyright: ignore
-        )
-    from disnake.types.voice import GuildVoiceState as GuildVoiceStatePayload
     from disnake.utils import MISSING
+
+    if TYPE_CHECKING:
+        if version_info >= (2, 6):
+            from disnake.types.gateway import (
+                VoiceServerUpdateEvent as VoiceServerUpdatePayload,  # pyright: ignore
+            )
+        else:
+            from disnake.types.voice import (
+                VoiceServerUpdate as VoiceServerUpdatePayload,  # pyright: ignore
+            )
+        from disnake.types.voice import GuildVoiceState as GuildVoiceStatePayload
 else:
     from discord import (
         Client,
@@ -109,11 +113,13 @@ else:
     )
     from discord.abc import Connectable, GuildChannel
     from discord.backoff import ExponentialBackoff
-    from discord.types.voice import (
-        GuildVoiceState as GuildVoiceStatePayload,
-        VoiceServerUpdate as VoiceServerUpdatePayload,
-    )
     from discord.utils import MISSING
+
+    if TYPE_CHECKING:
+        from discord.types.voice import (
+            GuildVoiceState as GuildVoiceStatePayload,
+            VoiceServerUpdate as VoiceServerUpdatePayload,
+        )
 
 
 try:


### PR DESCRIPTION
## Summary

Report from @Kraots <https://canary.discord.com/channels/864563184919773226/1075508816914960384/1075510719350571069>.

```py
Traceback (most recent call last):
  File "/home/Kraots/okiyu/main.py", line 17, in <module>
    import mafic
  File "/home/Kraots/venv/lib/python3.10/site-packages/mafic/__init__.py", line 13, in <module>
    from . import __libraries
  File "/home/Kraots/venv/lib/python3.10/site-packages/mafic/__libraries.py", line 92, in <module>
    from disnake.types.gateway import (
  File "/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/gateway.py", line 11, in <module>
    from .audit_log import AuditLogEntry
  File "/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/audit_log.py", line 17, in <module>
    from .channel import ChannelType, PermissionOverwrite, VideoQualityMode
  File "/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/channel.py", line 8, in <module>
    from .threads import ForumTag, ThreadArchiveDurationLiteral, ThreadMember, ThreadMetadata
  File "/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/threads.py", line 11, in <module>
    from .message import Message
  File "/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/message.py", line 9, in <module>
    from .channel import ChannelType
ImportError: cannot import name 'ChannelType' from partially initialized module 'disnake.types.channel' (most likely due to a circular import) (/home/Kraots/venv/lib/python3.10/site-packages/disnake/types/channel.py)
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
