### PR TITLE
fix(node): stop appending /v3 if done already

### DIFF
--- a/mafic/node.py
+++ b/mafic/node.py
@@ -391,6 +391,12 @@ class Node(Generic[ClientT]):
             Some features may not work.
         """
 
+        if self._rest_uri.path.endswith("/v3") or self._ws_uri.path.endswith(
+            "/websocket"
+        ):
+            # This process was already ran likely.
+            return
+
         if self.__session is None:
             self.__session = await self._create_session()
 


### PR DESCRIPTION
## Summary

From `Cattosarus` on [Discord](https://canary.discord.com/channels/864563184919773226/1074660965347504190/1075015900652109824)

```py
14.02.2023 13:26:07 | ERROR | An HTTP error occured: {"timestamp":1676373968330,"status":404,"error":"Not Found","message":"Not Found","path":"/v3/v3/loadtracks"} (404)
Traceback (most recent call last):
  File "C:\Users\Cattosarus\Desktop\mafic-bot\cogs\music.py", line 89, in play
    results = await player.fetch_tracks(query)
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\player.py", line 457, in fetch_tracks
    return await node.fetch_tracks(query, search_type=raw_type)
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\node.py", line 891, in fetch_tracks
    data: TrackLoadingResult = await self.__request(
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\node.py", line 854, in __request
    raise HTTPNotFound(text)
mafic.errors.HTTPNotFound: An HTTP error occured: {"timestamp":1676373968330,"status":404,"error":"Not Found","message":"Not Found","path":"/v3/v3/loadtracks"} (404)
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
