### PR TITLE
feat(player): expose Player.paused

### DIFF
--- a/mafic/player.py
+++ b/mafic/player.py
@@ -97,6 +97,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
         self._filters: OrderedDict[str, Filter] = OrderedDict()
         # Used to get the last track for TrackEndEvent.
         self._last_track: Track | None = None
+        self._paused: bool = False
 
     def __repr__(self) -> str:
         attrs = (
@@ -154,6 +155,12 @@ class Player(VoiceProtocol, Generic[ClientT]):
         """The current track that is playing."""
 
         return self._current
+
+    @property
+    def paused(self) -> bool:
+        """Whether the player is paused."""
+
+        return self._paused
 
     def update_state(self, state: PlayerUpdateState) -> None:
         """Update the player state.
@@ -511,6 +518,9 @@ class Player(VoiceProtocol, Generic[ClientT]):
             filter=filter,
             no_replace=not replace,
         )
+
+        if pause is not None:
+            self._paused = pause
 
     async def play(
         self,


### PR DESCRIPTION
## Summary

Add `Player.paused` property to expose the current paused state.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
