### PR TITLE
fix(pool): ignore unavailable nodes

### DIFF
--- a/mafic/pool.py
+++ b/mafic/pool.py
@@ -174,8 +174,6 @@ class NodePool(Generic[ClientT]):
             shard_ids=shard_ids,
         )
 
-        self._nodes[label] = node
-
         # Add to dictionaries, creating a set or extending it if needed.
         if node.regions:
             for region in node.regions:
@@ -194,6 +192,7 @@ class NodePool(Generic[ClientT]):
         _log.info("Created node, connecting it...", extra={"label": label})
         await node.connect()
 
+        self._nodes[label] = node
         return node
 
     @classmethod
@@ -279,4 +278,7 @@ class NodePool(Generic[ClientT]):
             If there are no nodes.
         """
 
-        return choice(list(cls._nodes.values()))
+        if node := choice(list(cls._nodes.values())):
+            return node
+
+        raise NoNodesAvailable


### PR DESCRIPTION
## Summary

This PR alters `NodePool` to not store unavailable nodes.

```py
14.02.2023 13:19:06 | WARNING | Unable to use best node, player not connected, finding random node.
14.02.2023 13:19:06 | ERROR | No nodes found for the region, defaulting to all nodes.
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have run `task lint` to format code and my changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
