### PR TITLE
fix(player): set blank filter if no filters enabled

### DIFF
--- a/mafic/player.py
+++ b/mafic/player.py
@@ -632,10 +632,9 @@ class Player(VoiceProtocol, Generic[ClientT]):
             Whether to seek to the current position after updating the filters.
         """
 
-        if not self._filters:
-            await self.update(filter=Filter())
-
-        await self.update(filter=reduce(or_, self._filters.values()))
+        await self.update(
+            filter=reduce(or_, self._filters.values()) if self._filters else Filter()
+        )
 
         if fast_apply:
             await self.seek(self.position)

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -632,6 +632,9 @@ class Player(VoiceProtocol, Generic[ClientT]):
             Whether to seek to the current position after updating the filters.
         """
 
+        if not self._filters:
+            await self.update(filter=Filter())
+
         await self.update(filter=reduce(or_, self._filters.values()))
 
         if fast_apply:

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -11,7 +11,18 @@ from botbase import BotBase
 from nextcord import Intents, Interaction
 from nextcord.abc import Connectable
 
-from mafic import Group, NodePool, Player, Playlist, Region, Track, TrackEndEvent
+from mafic import (
+    EQBand,
+    Equalizer,
+    Filter,
+    Group,
+    NodePool,
+    Player,
+    Playlist,
+    Region,
+    Track,
+    TrackEndEvent,
+)
 
 getLogger("mafic").setLevel(DEBUG)
 
@@ -245,6 +256,33 @@ async def stats(inter: Interaction):
             playing_player_count=stats.playing_player_count,
         )
     )
+
+
+@bot.slash_command()
+async def boost(inter: Interaction):
+    if not inter.guild.voice_client:
+        return await inter.send("I am not in a voice channel.")
+
+    player: MyPlayer = inter.guild.voice_client
+
+    bassboost_equalizer = Equalizer([EQBand(idx, 0.30) for idx in range(0, 15)])
+
+    bassboost_filter = Filter(bassboost_equalizer)
+    await player.add_filter(bassboost_filter, label="boost")
+
+    await inter.send("Boost enabled.")
+
+
+@bot.slash_command()
+async def unboost(inter: Interaction):
+    if not inter.guild.voice_client:
+        return await inter.send("I am not in a voice channel.")
+
+    player: MyPlayer = inter.guild.voice_client
+
+    await player.remove_filter("boost")
+
+    await inter.send("Boost disabled.")
 
 
 bot.run(getenv("TOKEN"))


### PR DESCRIPTION
## Summary

Set a blank filter if no filters are applied and are updated.

<https://canary.discord.com/channels/864563184919773226/1076074968087011409/1076074968087011409>

```py
17.02.2023 11:26:46 | INFO | Cattosarus#0463 ran application command "bassboost"
Ignoring exception in command <nextcord.application_command.SlashApplicationCommand object at 0x00000140A183F700>:
Traceback (most recent call last):
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\nextcord\application_command.py", line 863, in invoke_callback_with_hooks
    await self(interaction, *args, **kwargs)
  File "c:\Users\Cattosarus\Desktop\mafic-bot\cogs\music.py", line 258, in bassboost
    await player.remove_filter("bassboost")
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\player.py", line 689, in remove_filter
    await self._update_filters(fast_apply=fast_apply)
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\player.py", line 635, in _update_filters
    await self.update(filter=reduce(or_, self._filters.values()))
TypeError: reduce() of empty sequence with no initial value

The above exception was the direct cause of the following exception:

nextcord.errors.ApplicationInvokeError: Command raised an exception: TypeError: reduce() of empty sequence with no initial value
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have run `task lint` to format code and my changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
