### PR TITLE
fix(node): ignore no content responses

### DIFF
--- a/mafic/node.py
+++ b/mafic/node.py
@@ -853,6 +853,9 @@ class Node(Generic[ClientT]):
         ) as resp:
             _log.debug("Received status %s from lavalink.", resp.status)
             if not (200 <= resp.status < 300):
+                if resp.status == 204:
+                    return None
+
                 text = await resp.text()
 
                 if resp.status == 400:


### PR DESCRIPTION
## Summary

Should resolve all issues like the following:

```py
Ignoring exception in command <nextcord.application_command.SlashApplicationCommand object at 0x0000012B6C8E06A0>:
Traceback (most recent call last):
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\nextcord\application_command.py", line 863, in invoke_callback_with_hooks
    await self(interaction, *args, **kwargs)
  File "c:\Users\Cattosarus\Desktop\mafic-bot\cogs\music.py", line 319, in destroy
    await player.destroy()
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\player.py", line 430, in destroy
    await self._node.destroy(guild_id=self.guild.id)
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\node.py", line 871, in __request
    json = await resp.json(loads=loads)
  File "C:\Users\Cattosarus\AppData\Local\Programs\Python\Python39\lib\site-packages\aiohttp\client_reqrep.py", line 1104, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: ', url=URL('https://node2.lewdhutao.tech:443/v3/sessions/4m8s81tmqk2bfc2p/players/1071227694685110343')

The above exception was the direct cause of the following exception:

nextcord.errors.ApplicationInvokeError: Command raised an exception: ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: ', url=URL('https://node2.lewdhutao.tech:443/v3/sessions/4m8s81tmqk2bfc2p/players/1071227694685110343')
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have run `task lint` to format code and my changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
