### PR TITLE
chore: use ruff over flake8 and isort

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 88
-per-file-ignores =
-    __init__.py: F401
-# Black already handles E501 - line too long, ignored for docstring anomolies.
-# W503 - line break before binary operator, ignored for Black, flake8 cannot decide what style lmao.
-extend-ignore = E501,W503,F403,F405

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,6 @@ repos:
       - id: black
         name: Running black in all files.
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: Running isort in all files.
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.251
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: isort
         name: Running isort in all files.
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.251
     hooks:
-      - id: flake8
-        name: Running flake8 in all files.
-        additional_dependencies: [flake8-isort, Flake8-pyproject]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        name: Running ruff in all files.
 
   - repo: https://github.com/ariebovenberg/slotscheck
     rev: v0.16.4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from sphinx.config import Config
+if TYPE_CHECKING:
+    from sphinx.config import Config
 
 os.environ["MAFIC_IGNORE_LIBRARY_CHECK"] = "1"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ aliases = {
 }
 
 
-def typehints_formatter(annotation: Any, _: Config) -> str | None:
+def typehints_formatter(annotation: Any, _: Config) -> str | None:  # noqa: ANN401
     return aliases.get(annotation, None)
 
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 import re
 from collections import OrderedDict
-from typing import Callable, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 from docutils import nodes
 from docutils.nodes import document
@@ -207,8 +207,9 @@ def process_attributetable(app: Sphinx, doctree: document, fromdocname: str):
             if not subitems:
                 continue
 
-            key: Callable[[TableElement], str] = lambda c: c.label
-            table.append(class_results_to_node(label, sorted(subitems, key=key)))
+            table.append(
+                class_results_to_node(label, sorted(subitems, key=lambda c: c.label))
+            )
 
         table["python-class"] = fullname
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -77,30 +77,30 @@ def visit_attributetable_item_node(self: HTML5Translator, node: attributetable) 
     self.body.append(self.starttag(node, "li", CLASS="py-attribute-table-entry"))
 
 
-def depart_attributetable_node(self: HTML5Translator, node: attributetable) -> None:
+def depart_attributetable_node(self: HTML5Translator, _node: attributetable) -> None:
     self.body.append("</div>")
 
 
 def depart_attributetablecolumn_node(
-    self: HTML5Translator, node: attributetablecolumn
+    self: HTML5Translator, _node: attributetablecolumn
 ) -> None:
     self.body.append("</div>")
 
 
 def depart_attributetabletitle_node(
-    self: HTML5Translator, node: attributetabletitle
+    self: HTML5Translator, _node: attributetabletitle
 ) -> None:
     self.body.append("</span>")
 
 
 def depart_attributetablebadge_node(
-    self: HTML5Translator, node: attributetablebadge
+    self: HTML5Translator, _node: attributetablebadge
 ) -> None:
     self.body.append("</span>")
 
 
 def depart_attributetable_item_node(
-    self: HTML5Translator, node: attributetable_item
+    self: HTML5Translator, _node: attributetable_item
 ) -> None:
     self.body.append("</li>")
 
@@ -203,7 +203,7 @@ class TableElement(NamedTuple):
     badge: attributetablebadge | None
 
 
-def process_attributetable(app: Sphinx, doctree: document, fromdocname: str) -> None:
+def process_attributetable(app: Sphinx, doctree: document, _fromdocname: str) -> None:
     env = app.builder.env
 
     lookup = build_lookup_table(env)

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 import re
 from collections import OrderedDict
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from docutils import nodes
 from docutils.nodes import document
@@ -44,20 +44,26 @@ class attributetable_item(nodes.Part, nodes.Element):
     pass
 
 
-def visit_attributetable_node(self: HTML5Translator, node: attributetable):
+def visit_attributetable_node(self: HTML5Translator, node: attributetable) -> None:
     class_ = node["python-class"]
     self.body.append(f'<div class="py-attribute-table" data-move-to-id="{class_}">')
 
 
-def visit_attributetablecolumn_node(self: HTML5Translator, node: attributetablecolumn):
+def visit_attributetablecolumn_node(
+    self: HTML5Translator, node: attributetablecolumn
+) -> None:
     self.body.append(self.starttag(node, "div", CLASS="py-attribute-table-column"))
 
 
-def visit_attributetabletitle_node(self: HTML5Translator, node: attributetabletitle):
+def visit_attributetabletitle_node(
+    self: HTML5Translator, node: attributetabletitle
+) -> None:
     self.body.append(self.starttag(node, "span"))
 
 
-def visit_attributetablebadge_node(self: HTML5Translator, node: attributetablebadge):
+def visit_attributetablebadge_node(
+    self: HTML5Translator, node: attributetablebadge
+) -> None:
     attributes = {
         "class": "py-attribute-table-badge",
         "title": node["badge-type"],
@@ -65,27 +71,35 @@ def visit_attributetablebadge_node(self: HTML5Translator, node: attributetableba
     self.body.append(self.starttag(node, "span", **attributes))
 
 
-def visit_attributetable_item_node(self: HTML5Translator, node: attributetable):
+def visit_attributetable_item_node(self: HTML5Translator, node: attributetable) -> None:
     self.body.append(self.starttag(node, "li", CLASS="py-attribute-table-entry"))
 
 
-def depart_attributetable_node(self: HTML5Translator, node: attributetable):
+def depart_attributetable_node(self: HTML5Translator, node: attributetable) -> None:
     self.body.append("</div>")
 
 
-def depart_attributetablecolumn_node(self: HTML5Translator, node: attributetablecolumn):
+def depart_attributetablecolumn_node(
+    self: HTML5Translator, node: attributetablecolumn
+) -> None:
     self.body.append("</div>")
 
 
-def depart_attributetabletitle_node(self: HTML5Translator, node: attributetabletitle):
+def depart_attributetabletitle_node(
+    self: HTML5Translator, node: attributetabletitle
+) -> None:
     self.body.append("</span>")
 
 
-def depart_attributetablebadge_node(self: HTML5Translator, node: attributetablebadge):
+def depart_attributetablebadge_node(
+    self: HTML5Translator, node: attributetablebadge
+) -> None:
     self.body.append("</span>")
 
 
-def depart_attributetable_item_node(self: HTML5Translator, node: attributetable_item):
+def depart_attributetable_item_node(
+    self: HTML5Translator, node: attributetable_item
+) -> None:
     self.body.append("</li>")
 
 
@@ -99,7 +113,7 @@ class PyAttributeTable(SphinxDirective):
     final_argument_whitespace = False
     option_spec = {}
 
-    def parse_name(self, content: str):
+    def parse_name(self, content: str) -> tuple[str, str]:
         match = _name_parser_regex.match(content)
         if match is None:
             raise RuntimeError("could not find module name somehow")
@@ -118,7 +132,7 @@ class PyAttributeTable(SphinxDirective):
 
         return modulename, name
 
-    def run(self):
+    def run(self) -> list[attributetableplaceholder]:
         """If you're curious on the HTML this is meant to generate:
 
         <div class="py-attribute-table">
@@ -155,7 +169,7 @@ class PyAttributeTable(SphinxDirective):
         return [node]
 
 
-def build_lookup_table(env: BuildEnvironment):
+def build_lookup_table(env: BuildEnvironment) -> dict[str, list[str]]:
     # Given an environment, load up a lookup table of
     # full-class-name: objects
     result: dict[str, list[str]] = {}
@@ -184,10 +198,10 @@ def build_lookup_table(env: BuildEnvironment):
 class TableElement(NamedTuple):
     fullname: str
     label: str
-    badge: Optional[attributetablebadge]
+    badge: attributetablebadge | None
 
 
-def process_attributetable(app: Sphinx, doctree: document, fromdocname: str):
+def process_attributetable(app: Sphinx, doctree: document, fromdocname: str) -> None:
     env = app.builder.env
 
     lookup = build_lookup_table(env)
@@ -221,7 +235,7 @@ def process_attributetable(app: Sphinx, doctree: document, fromdocname: str):
 
 def get_class_results(
     lookup: dict[str, list[str]], modulename: str, name: str, fullname: str
-):
+) -> OrderedDict[str, list[TableElement]]:
     module = importlib.import_module(modulename)
     cls = getattr(module, name)
 
@@ -276,7 +290,9 @@ def get_class_results(
     return groups
 
 
-def class_results_to_node(key: str, elements: list[TableElement]):
+def class_results_to_node(
+    key: str, elements: list[TableElement]
+) -> attributetablecolumn:
     title = attributetabletitle(key, key)
     ul = nodes.bullet_list("")
     for element in elements:
@@ -297,7 +313,7 @@ def class_results_to_node(key: str, elements: list[TableElement]):
     return attributetablecolumn("", title, ul)
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> None:
     app.add_directive("attributetable", PyAttributeTable)
     app.add_node(
         attributetable, html=(visit_attributetable_node, depart_attributetable_node)

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -299,10 +299,10 @@ def class_results_to_node(
         ref = nodes.reference(
             "",
             "",
+            *[nodes.Text(element.label)],
             internal=True,
             refuri="#" + element.fullname,
             anchorname="",
-            *[nodes.Text(element.label)],
         )
         para = addnodes.compact_paragraph("", "", ref)
         if element.badge is not None:

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -8,16 +8,18 @@ import importlib
 import inspect
 import re
 from collections import OrderedDict
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from docutils import nodes
-from docutils.nodes import document
 from sphinx import addnodes
-from sphinx.application import Sphinx
-from sphinx.environment import BuildEnvironment
 from sphinx.locale import _
 from sphinx.util.docutils import SphinxDirective
-from sphinx.writers.html5 import HTML5Translator
+
+if TYPE_CHECKING:
+    from docutils.nodes import document
+    from sphinx.application import Sphinx
+    from sphinx.environment import BuildEnvironment
+    from sphinx.writers.html5 import HTML5Translator
 
 
 class attributetable(nodes.General, nodes.Element):

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -116,7 +116,8 @@ class PyAttributeTable(SphinxDirective):
     def parse_name(self, content: str) -> tuple[str, str]:
         match = _name_parser_regex.match(content)
         if match is None:
-            raise RuntimeError("could not find module name somehow")
+            msg = "could not find module name somehow"
+            raise RuntimeError(msg)
 
         path, name = match.groups()
         if path:
@@ -126,9 +127,8 @@ class PyAttributeTable(SphinxDirective):
             if not modulename:
                 modulename = self.env.ref_context.get("py:module")
         if modulename is None:
-            raise RuntimeError(
-                f"modulename somehow None for {content} in {self.env.docname}."
-            )
+            msg = f"modulename somehow None for {content} in {self.env.docname}."
+            raise RuntimeError(msg)
 
         return modulename, name
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -113,7 +113,7 @@ class PyAttributeTable(SphinxDirective):
                 modulename = self.env.ref_context.get("py:module")
         if modulename is None:
             raise RuntimeError(
-                "modulename somehow None for %s in %s." % (content, self.env.docname)
+                f"modulename somehow None for {content} in {self.env.docname}."
             )
 
         return modulename, name

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -211,9 +211,9 @@ def process_attributetable(app: Sphinx, doctree: document, fromdocname: str) -> 
             node["python-class"],
             node["python-full-name"],
         )
-        assert isinstance(modulename, str)
-        assert isinstance(classname, str)
-        assert isinstance(fullname, str)
+        assert isinstance(modulename, str)  # noqa: S101
+        assert isinstance(classname, str)  # noqa: S101
+        assert isinstance(fullname, str)  # noqa: S101
 
         groups = get_class_results(lookup, modulename, classname, fullname)
         table = attributetable("")

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -24,7 +24,7 @@ def visit_exception_hierarchy_node(
 
 
 def depart_exception_hierarchy_node(
-    self: HTML5Translator, node: exception_hierarchy
+    self: HTML5Translator, _node: exception_hierarchy
 ) -> None:
     self.body.append("</div>\n")
 

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -13,25 +13,29 @@ class exception_hierarchy(nodes.General, nodes.Element):
     pass
 
 
-def visit_exception_hierarchy_node(self: HTML5Translator, node: exception_hierarchy):
+def visit_exception_hierarchy_node(
+    self: HTML5Translator, node: exception_hierarchy
+) -> None:
     self.body.append(self.starttag(node, "div", CLASS="exception-hierarchy-content"))
 
 
-def depart_exception_hierarchy_node(self: HTML5Translator, node: exception_hierarchy):
+def depart_exception_hierarchy_node(
+    self: HTML5Translator, node: exception_hierarchy
+) -> None:
     self.body.append("</div>\n")
 
 
 class ExceptionHierarchyDirective(Directive):
     has_content = True
 
-    def run(self):
+    def run(self) -> list[exception_hierarchy]:
         self.assert_has_content()
         node = exception_hierarchy("\n".join(self.content))
         self.state.nested_parse(self.content, self.content_offset, node)
         return [node]
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> None:
     app.add_node(
         exception_hierarchy,
         html=(visit_exception_hierarchy_node, depart_exception_hierarchy_node),

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -3,10 +3,14 @@
 # pyright: reportUnknownArgumentType=false
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from sphinx.application import Sphinx
-from sphinx.writers.html5 import HTML5Translator
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.writers.html5 import HTML5Translator
 
 
 class exception_hierarchy(nodes.General, nodes.Element):

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import traceback
 from logging import DEBUG, getLogger
 from os import getenv
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nextcord import Intents, Interaction, Member
-from nextcord.abc import Connectable
 from nextcord.ext import commands
 
 from mafic import NodePool, Player, Playlist, Track, TrackEndEvent
+
+if TYPE_CHECKING:
+    from nextcord.abc import Connectable
 
 getLogger("mafic").setLevel(DEBUG)
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -51,7 +51,6 @@ class MyPlayer(Player[Bot]):
 @bot.slash_command(dm_permission=False)
 async def join(inter: Interaction[Bot]):
     """Join your voice channel."""
-
     assert isinstance(inter.user, Member)
 
     if not inter.user.voice or not inter.user.voice.channel:
@@ -71,7 +70,6 @@ async def play(inter: Interaction[Bot], query: str):
     query:
         The song to search or play.
     """
-
     assert inter.guild is not None
 
     if not inter.guild.voice_client:

--- a/mafic/__init__.py
+++ b/mafic/__init__.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""
-Mafic
-=====
-A properly typehinted lavalink client for discord.py, nextcord, disnake and py-cord.
+"""A properly typehinted lavalink client for discord.py, nextcord, disnake and py-cord.
 
 :copyright: (c) 2022-present ooliver1
 :license: MIT, see LICENSE for more details.

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -135,4 +135,5 @@ except ImportError:
 
 
 if version_info.major != 2:
-    raise RuntimeError(f"Mafic requires version 2 of {library}.")
+    msg = f"Mafic requires version 2 of {library}."
+    raise RuntimeError(msg)

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -119,8 +119,8 @@ else:
 
     if TYPE_CHECKING:
         from discord.types.voice import (
-            GuildVoiceState as GuildVoiceStatePayload,
-            VoiceServerUpdate as VoiceServerUpdatePayload,
+            GuildVoiceState as GuildVoiceStatePayload,  # noqa: TCH004
+            VoiceServerUpdate as VoiceServerUpdatePayload,  # noqa: TCH004
         )
 
 

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from os import getenv
 from typing import TYPE_CHECKING, Any
 
-from pkg_resources import get_distribution  # pyright: ignore[reportUnknownVariableType]
-from pkg_resources import DistributionNotFound
+from pkg_resources import (
+    DistributionNotFound,
+    get_distribution,  # pyright: ignore[reportUnknownVariableType]
+)
 
 from .errors import MultipleCompatibleLibraries, NoCompatibleLibraries
 

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -42,7 +42,7 @@ for library in libraries:
         found.append(library)
 
 
-if not getenv("MAFIC_IGNORE_LIBRARY_CHECK", False):
+if not getenv("MAFIC_IGNORE_LIBRARY_CHECK", default=False):
     if len(found) == 0:
         raise NoCompatibleLibraries
     elif len(found) > 1:

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -127,7 +127,7 @@ else:
 try:
     from orjson import dumps as _dumps, loads
 
-    def dumps(obj: Any) -> str:
+    def dumps(obj: Any) -> str:  # noqa: ANN401
         return _dumps(obj).decode()
 
 except ImportError:

--- a/mafic/__main__.py
+++ b/mafic/__main__.py
@@ -26,7 +26,7 @@ def show_version() -> None:
     """Show version information."""
     version = mafic.__version__
     uname = platform.uname()
-    print(
+    print(  # noqa: T201
         VERSION_OUTPUT.format(
             py=sys.version_info,
             mafic=version,

--- a/mafic/__main__.py
+++ b/mafic/__main__.py
@@ -1,3 +1,4 @@
+"""Mafic CLI tools."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ VERSION_OUTPUT = """
 
 
 def show_version() -> None:
+    """Show version information."""
     version = mafic.__version__
     uname = platform.uname()
     print(
@@ -37,11 +39,13 @@ def show_version() -> None:
 
 
 def core(_: ArgumentParser, args: Namespace) -> None:
+    """Core function for mafic CLI tools."""
     if args.version:
         show_version()
 
 
 def parse_args() -> tuple[ArgumentParser, Namespace]:
+    """Parse arguments from the CLI."""
     parser = ArgumentParser(prog="mafic", description="CLI tools for mafic")
     parser.add_argument(
         "-v",
@@ -53,6 +57,7 @@ def parse_args() -> tuple[ArgumentParser, Namespace]:
 
 
 def main() -> None:
+    """Run the parser for arguments then execute."""
     parser, args = parse_args()
     core(parser, args)
 

--- a/mafic/errors.py
+++ b/mafic/errors.py
@@ -71,6 +71,8 @@ class TrackLoadException(PlayerException):
         The message returned by the node.
     severity: :data:`~typing.Literal`\[``"COMMON"``, ``"SUSPICIOUS"``, ``"FATAL"``]
         The severity of the error.
+    cause: :class:`str`
+        The cause of the error.
     """
 
     def __init__(
@@ -80,6 +82,7 @@ class TrackLoadException(PlayerException):
 
         self.message: str = message
         self.severity: ExceptionSeverity = severity
+        self.cause: str = cause
 
     @classmethod
     def from_data(cls, data: LavalinkException) -> Self:

--- a/mafic/errors.py
+++ b/mafic/errors.py
@@ -1,3 +1,4 @@
+"""Errors raised by Mafic."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -62,13 +63,13 @@ class PlayerException(MaficException):
 
 
 class TrackLoadException(PlayerException):
-    """This is raised when a track could not be loaded.
+    r"""An error raised when a track could not be loaded.
 
     Attributes
     ----------
     message: :class:`str`
         The message returned by the node.
-    severity: :data:`~typing.Literal`\\[``"COMMON"``, ``"SUSPICIOUS"``, ``"FATAL"``]
+    severity: :data:`~typing.Literal`\[``"COMMON"``, ``"SUSPICIOUS"``, ``"FATAL"``]
         The severity of the error.
     """
 
@@ -94,28 +95,27 @@ class TrackLoadException(PlayerException):
         TrackLoadException
             The constructed exception.
         """
-
         return cls(
             message=data["message"], severity=data["severity"], cause=data["cause"]
         )
 
 
 class PlayerNotConnected(PlayerException):
-    """This is raised when a player is not connected to a voice channel."""
+    """An error raised when a player is not connected to a voice channel."""
 
     def __init__(self) -> None:
         super().__init__("The player is not connected to a voice channel.")
 
 
 class NodeAlreadyConnected(MaficException):
-    """This is raised when a node is already connected to Mafic."""
+    """An error raised when a node is already connected to Mafic."""
 
     def __init__(self) -> None:
         super().__init__("The node is already connected to Mafic.")
 
 
 class NoNodesAvailable(MaficException):
-    """This is raised when no nodes are available to handle a player."""
+    """An error raised when no nodes are available to handle a player."""
 
     def __init__(self) -> None:
         super().__init__("No nodes are available to handle this player.")
@@ -132,21 +132,21 @@ class HTTPException(MaficException):
 
 
 class HTTPBadRequest(HTTPException):
-    """This is raised when a bad request is made to the Lavalink REST API."""
+    """An error raised when a bad request is made to the Lavalink REST API."""
 
     def __init__(self, message: str) -> None:
         super().__init__(400, message)
 
 
 class HTTPUnauthorized(HTTPException):
-    """This is raised when an unauthorized request is made to the Lavalink REST API."""
+    """An error raised when an unauthorized request is made to the Lavalink REST API."""
 
     def __init__(self, message: str) -> None:
         super().__init__(401, message)
 
 
 class HTTPNotFound(HTTPException):
-    """This is raised when a request is made to a non-existent endpoint."""
+    """An error raised when a request is made to a non-existent endpoint."""
 
     def __init__(self, message: str) -> None:
         super().__init__(404, message)

--- a/mafic/events.py
+++ b/mafic/events.py
@@ -1,3 +1,4 @@
+"""Objects for dispatched events via the client."""
 # SPDX-License-Identifier: MIT
 # pyright: reportImportCycles=false
 # Player import.
@@ -79,6 +80,7 @@ class WebSocketClosedEvent(Generic[PlayerT]):
         self.player: PlayerT = player
 
     def __repr__(self) -> str:
+        """Get a string representation of the event."""
         return (
             f"<WebSocketClosedEvent code={self.code} reason={self.reason!r} "
             f"by_discord={self.by_discord}>"
@@ -103,6 +105,7 @@ class TrackStartEvent(Generic[PlayerT]):
         self.player: PlayerT = player
 
     def __repr__(self) -> str:
+        """Get a string representation of the event."""
         return f"<TrackStartEvent track={self.track!r}>"
 
 
@@ -127,6 +130,7 @@ class TrackEndEvent(Generic[PlayerT]):
         self.player: PlayerT = player
 
     def __repr__(self) -> str:
+        """Get a string representation of the event."""
         return f"<TrackEndEvent track={self.track!r} reason={self.reason!r}>"
 
 
@@ -157,6 +161,7 @@ class TrackExceptionEvent(Generic[PlayerT]):
         self.player: PlayerT = player
 
     def __repr__(self) -> str:
+        """Get a string representation of the event."""
         return (
             f"<TrackExceptionEvent track={self.track!r} exception={self.exception!r}>"
         )
@@ -185,6 +190,7 @@ class TrackStuckEvent(Generic[PlayerT]):
         self.player: PlayerT = player
 
     def __repr__(self) -> str:
+        """Get a string representation of the event."""
         return (
             f"<TrackStuckEvent track={self.track!r} threshold_ms={self.threshold_ms}>"
         )

--- a/mafic/events.py
+++ b/mafic/events.py
@@ -61,7 +61,7 @@ class WebSocketClosedEvent(Generic[PlayerT]):
         The close code.
         Find what this can be in the Discord `docs`_.
 
-        .. _docs: https://discord.com/developers/docs/topics/opcodes-and-status-codes#close-event-codes.
+        .. _docs: https://discord.dev/topics/opcodes-and-status-codes#close-event-codes.
     reason: :class:`str`
         The close reason.
     by_discord: :class:`bool`

--- a/mafic/events.py
+++ b/mafic/events.py
@@ -73,7 +73,9 @@ class WebSocketClosedEvent(Generic[PlayerT]):
 
     __slots__ = ("code", "reason", "by_discord", "player")
 
-    def __init__(self, *, payload: WebSocketClosedEventPayload, player: PlayerT):
+    def __init__(
+        self, *, payload: WebSocketClosedEventPayload, player: PlayerT
+    ) -> None:
         self.code: int = payload["code"]
         self.reason: str = payload["reason"]
         self.by_discord: bool = payload["byRemote"]
@@ -100,7 +102,7 @@ class TrackStartEvent(Generic[PlayerT]):
 
     __slots__ = ("track", "player")
 
-    def __init__(self, *, track: Track, player: PlayerT):
+    def __init__(self, *, track: Track, player: PlayerT) -> None:
         self.track: Track = track
         self.player: PlayerT = player
 
@@ -124,7 +126,9 @@ class TrackEndEvent(Generic[PlayerT]):
 
     __slots__ = ("track", "reason", "player")
 
-    def __init__(self, *, track: Track, payload: TrackEndEventPayload, player: PlayerT):
+    def __init__(
+        self, *, track: Track, payload: TrackEndEventPayload, player: PlayerT
+    ) -> None:
         self.track: Track = track
         self.reason: EndReason = EndReason(payload["reason"])
         self.player: PlayerT = player
@@ -155,7 +159,7 @@ class TrackExceptionEvent(Generic[PlayerT]):
         track: Track,
         payload: TrackExceptionEventPayload,
         player: PlayerT,
-    ):
+    ) -> None:
         self.track: Track = track
         self.exception: LavalinkException = payload["exception"]
         self.player: PlayerT = player
@@ -184,7 +188,7 @@ class TrackStuckEvent(Generic[PlayerT]):
 
     def __init__(
         self, *, track: Track, payload: TrackStuckEventPayload, player: PlayerT
-    ):
+    ) -> None:
         self.track: Track = track
         self.threshold_ms: int = payload["thresholdMs"]
         self.player: PlayerT = player

--- a/mafic/filter.py
+++ b/mafic/filter.py
@@ -9,8 +9,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from typing_extensions import Self
 
     from .typings import (
@@ -641,9 +639,11 @@ class Filter:
 
         return self
 
-    def __or__(self, other: Any) -> Filter:
+    def __or__(self, other: Filter) -> Filter:
         """Merge two filters together, favouring attributes from other."""
-        if not isinstance(other, Filter):
+        if not isinstance(
+            other, Filter
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
         return Filter(
@@ -659,9 +659,11 @@ class Filter:
             volume=other.volume or self.volume,
         )
 
-    def __ior__(self, other: Any) -> None:
+    def __ior__(self, other: Filter) -> None:
         """Merge two filters together, favouring attributes from other, in place."""
-        if not isinstance(other, Filter):
+        if not isinstance(
+            other, Filter
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
         self.equalizer = other.equalizer or self.equalizer
@@ -675,9 +677,11 @@ class Filter:
         self.low_pass = other.low_pass or self.low_pass
         self.volume = other.volume or self.volume
 
-    def __and__(self, other: Any) -> Filter:
+    def __and__(self, other: Filter) -> Filter:
         """Merge two filters together, favouring attributes from self."""
-        if not isinstance(other, Filter):
+        if not isinstance(
+            other, Filter
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
         return Filter(
@@ -693,9 +697,11 @@ class Filter:
             volume=self.volume or other.volume,
         )
 
-    def __iand__(self, other: Any) -> None:
+    def __iand__(self, other: Filter) -> None:
         """Merge two filters together, favouring attributes from self, in place."""
-        if not isinstance(other, Filter):
+        if not isinstance(
+            other, Filter
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
         self.equalizer = self.equalizer or other.equalizer

--- a/mafic/filter.py
+++ b/mafic/filter.py
@@ -644,7 +644,8 @@ class Filter:
         if not isinstance(
             other, Filter
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise TypeError(f"Expected Filter instance, not {type(other)!r}")
+            msg = f"Expected Filter instance, not {type(other)!r}"
+            raise TypeError(msg)
 
         return Filter(
             equalizer=other.equalizer or self.equalizer,
@@ -664,7 +665,8 @@ class Filter:
         if not isinstance(
             other, Filter
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise TypeError(f"Expected Filter instance, not {type(other)!r}")
+            msg = f"Expected Filter instance, not {type(other)!r}"
+            raise TypeError(msg)
 
         self.equalizer = other.equalizer or self.equalizer
         self.karaoke = other.karaoke or self.karaoke
@@ -682,7 +684,8 @@ class Filter:
         if not isinstance(
             other, Filter
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise TypeError(f"Expected Filter instance, not {type(other)!r}")
+            msg = f"Expected Filter instance, not {type(other)!r}"
+            raise TypeError(msg)
 
         return Filter(
             equalizer=self.equalizer or other.equalizer,
@@ -702,7 +705,8 @@ class Filter:
         if not isinstance(
             other, Filter
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise TypeError(f"Expected Filter instance, not {type(other)!r}")
+            msg = f"Expected Filter instance, not {type(other)!r}"
+            raise TypeError(msg)
 
         self.equalizer = self.equalizer or other.equalizer
         self.karaoke = self.karaoke or other.karaoke

--- a/mafic/filter.py
+++ b/mafic/filter.py
@@ -1,3 +1,4 @@
+"""Filters that can be applied to a Player."""
 # SPDX-License-Identifier: MIT
 # Reference to filter meanings can be found in:
 # https://github.com/natanbc/lavadsp
@@ -61,19 +62,18 @@ class EQBand:
     @property
     def payload(self) -> EQBandPayload:
         """Generate the raw Lavalink payload for this band."""
-
         return {"band": self.band, "gain": self.gain}
 
 
 @dataclass(unsafe_hash=True)
 class Equalizer:
-    """Represents an `equaliser`_.
+    r"""Represents an `equaliser`_.
 
     .. _equaliser: https://en.wikipedia.org/wiki/Equalization_(audio)
 
     Attributes
     ----------
-    bands: :class:`list`\\[:class:`EQBand`]
+    bands: :class:`list`\[:class:`EQBand`]
         The bands to set the gains of.
     """
 
@@ -81,10 +81,12 @@ class Equalizer:
 
     @property
     def payload(self) -> list[EQBandPayload]:
+        """Generate the raw Lavalink payload for this equaliser."""
         return [band.payload for band in self.bands]
 
     @classmethod
     def from_payload(cls, payload: list[EQBandPayload]) -> Self:
+        """Generate an :class:`Equalizer` from a Lavalink payload."""
         return cls(
             bands=[EQBand(band=band["band"], gain=band["gain"]) for band in payload]
         )
@@ -92,24 +94,24 @@ class Equalizer:
 
 @dataclass(unsafe_hash=True)
 class Karaoke:
-    """Represents a filter which can be used to eliminate part of a band.
+    r"""Represents a filter which can be used to eliminate part of a band.
 
     This usually targets vocals, to sound like karaoke music.
 
     Attributes
     ----------
-    level: :data:`~typing.Optional`\\[:class:`float`]
+    level: :data:`~typing.Optional`\[:class:`float`]
         The level of the karaoke effect. Must be between ``0.0`` and ``1.0``.
         Where ``0.0`` is no effect and ``1.0`` is full effect.
         This defaults to ``1.0``.
-    mono_level: :data:`~typing.Optional`\\[:class:`float`]
+    mono_level: :data:`~typing.Optional`\[:class:`float`]
         The level of the mono effect. Must be between ``0.0`` and ``1.0``.
         Where ``0.0`` is no effect and ``1.0`` is full effect.
         This defaults to ``1.0``.
-    filter_band: :data:`~typing.Optional`\\[:class:`float`]
+    filter_band: :data:`~typing.Optional`\[:class:`float`]
         The frequency of the filter band in Hz.
         This defaults to ``220.0``.
-    filter_width: :data:`~typing.Optional`\\[:class:`float`]
+    filter_width: :data:`~typing.Optional`\[:class:`float`]
         The width of the filter band.
         This defaults to ``100.0``.
     """
@@ -122,7 +124,6 @@ class Karaoke:
     @property
     def payload(self) -> KaraokePayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: KaraokePayload = {}
 
         if self.level is not None:
@@ -141,6 +142,7 @@ class Karaoke:
 
     @classmethod
     def from_payload(cls, payload: KaraokePayload) -> Self:
+        """Generate a :class:`Karaoke` from a Lavalink payload."""
         return cls(
             level=payload.get("level"),
             mono_level=payload.get("monoLevel"),
@@ -151,16 +153,15 @@ class Karaoke:
 
 @dataclass(unsafe_hash=True)
 class Timescale:
-    """Represents a filter which can be used to change the speed,
-    pitch and rate of audio.
+    r"""Represents a filter which is used to change the speed, pitch and rate of audio.
 
     Attributes
     ----------
-    speed: :data:`~typing.Optional`\\[:class:`float`]
+    speed: :data:`~typing.Optional`\[:class:`float`]
         The speed of the audio. Must be at least ``0.0``. ``1.0`` is normal speed.
-    pitch: :data:`~typing.Optional`\\[:class:`float`]
+    pitch: :data:`~typing.Optional`\[:class:`float`]
         The pitch of the audio. Must be at least ``0.0``. ``1.0`` is normal pitch.
-    rate: :data:`~typing.Optional`\\[:class:`float`]
+    rate: :data:`~typing.Optional`\[:class:`float`]
         The rate of the audio. Must be at least ``0.0``. ``1.0`` is normal rate.
     """
 
@@ -171,7 +172,6 @@ class Timescale:
     @property
     def payload(self) -> TimescalePayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: TimescalePayload = {}
 
         if self.speed is not None:
@@ -187,6 +187,7 @@ class Timescale:
 
     @classmethod
     def from_payload(cls, payload: TimescalePayload) -> Self:
+        """Generate a :class:`Timescale` from a Lavalink payload."""
         return cls(
             speed=payload.get("speed"),
             pitch=payload.get("pitch"),
@@ -196,7 +197,7 @@ class Timescale:
 
 @dataclass(unsafe_hash=True)
 class Tremolo:
-    """Represents a filter which can be used to add a `tremolo`_ effect to audio.
+    r"""Represents a filter which can be used to add a `tremolo`_ effect to audio.
 
     Tremolo oscillates the volume of the audio.
 
@@ -204,10 +205,10 @@ class Tremolo:
 
     Attributes
     ----------
-    frequency: :data:`~typing.Optional`\\[:class:`float`]
+    frequency: :data:`~typing.Optional`\[:class:`float`]
         The frequency of the tremolo effect. Must be at least ``0.0``.
         This defaults to ``2.0``.
-    depth: :data:`~typing.Optional`\\[:class:`float`]
+    depth: :data:`~typing.Optional`\[:class:`float`]
         The depth of the tremolo effect. Must be between ``0.0`` and ``1.0``.
         Where ``0.0`` is no effect and ``1.0`` is full effect.
         This defaults to ``0.5``.
@@ -219,7 +220,6 @@ class Tremolo:
     @property
     def payload(self) -> TremoloPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: TremoloPayload = {}
 
         if self.frequency is not None:
@@ -232,6 +232,7 @@ class Tremolo:
 
     @classmethod
     def from_payload(cls, payload: TremoloPayload) -> Self:
+        """Generate a :class:`Tremolo` from a Lavalink payload."""
         return cls(
             frequency=payload.get("frequency"),
             depth=payload.get("depth"),
@@ -240,7 +241,7 @@ class Tremolo:
 
 @dataclass(repr=True)
 class Vibrato:
-    """Represents a filter which can be used to add a `vibrato`_ effect to audio.
+    r"""Represents a filter which can be used to add a `vibrato`_ effect to audio.
 
     Vibrato oscillates the pitch of the audio.
 
@@ -248,10 +249,10 @@ class Vibrato:
 
     Attributes
     ----------
-    frequency: :data:`~typing.Optional`\\[:class:`float`]
+    frequency: :data:`~typing.Optional`\[:class:`float`]
         The frequency of the vibrato effect. Must be at least ``0.0``.
         This defaults to ``2.0``.
-    depth: :data:`~typing.Optional`\\[:class:`float`]
+    depth: :data:`~typing.Optional`\[:class:`float`]
         The depth of the vibrato effect. Must be between ``0.0`` and ``1.0``.
         Where ``0.0`` is no effect and ``1.0`` is full effect.
         This defaults to ``0.5``.
@@ -263,7 +264,6 @@ class Vibrato:
     @property
     def payload(self) -> VibratoPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: VibratoPayload = {}
 
         if self.frequency is not None:
@@ -276,6 +276,7 @@ class Vibrato:
 
     @classmethod
     def from_payload(cls, payload: VibratoPayload) -> Self:
+        """Generate a :class:`Vibrato` from a Lavalink payload."""
         return cls(
             frequency=payload.get("frequency"),
             depth=payload.get("depth"),
@@ -284,7 +285,7 @@ class Vibrato:
 
 @dataclass(unsafe_hash=True)
 class Rotation:
-    """Represents a filter which can be used to add a rotating effect to audio.
+    r"""Represents a filter which can be used to add a rotating effect to audio.
 
     An example can be with `"8D audio" (without the reverb)`_.
 
@@ -292,7 +293,7 @@ class Rotation:
 
     Attributes
     ----------
-    rotation_hz: :data:`~typing.Optional`\\[:class:`float`]
+    rotation_hz: :data:`~typing.Optional`\[:class:`float`]
         The rotation speed in Hz. Must be at least ``0.0``.
         ``0.2`` is similar to the example above.
     """
@@ -302,7 +303,6 @@ class Rotation:
     @property
     def payload(self) -> RotationPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: RotationPayload = {}
 
         if self.rotation_hz is not None:
@@ -312,6 +312,7 @@ class Rotation:
 
     @classmethod
     def from_payload(cls, payload: RotationPayload) -> Self:
+        """Generate a :class:`Rotation` from a Lavalink payload."""
         return cls(
             rotation_hz=payload.get("rotationHz"),
         )
@@ -319,7 +320,7 @@ class Rotation:
 
 @dataclass(unsafe_hash=True)
 class Distortion:
-    """Represents a filter which can be used to add a distortion effect to audio.
+    r"""Represents a filter which can be used to add a distortion effect to audio.
 
     This applies sine, cosine and tangent distortion to the audio.
     The formula that is used::
@@ -338,28 +339,28 @@ class Distortion:
 
     Attributes
     ----------
-    sin_offset: :data:`~typing.Optional`\\[:class:`float`]
+    sin_offset: :data:`~typing.Optional`\[:class:`float`]
         The offset of the sine distortion.
         This defaults to ``0.0``.
-    sin_scale: :data:`~typing.Optional`\\[:class:`float`]
+    sin_scale: :data:`~typing.Optional`\[:class:`float`]
         The scale of the sine distortion.
         This defaults to ``1.0``.
-    cos_offset: :data:`~typing.Optional`\\[:class:`float`]
+    cos_offset: :data:`~typing.Optional`\[:class:`float`]
         The offset of the cosine distortion.
         This defaults to ``0.0``.
-    cos_scale: :data:`~typing.Optional`\\[:class:`float`]
+    cos_scale: :data:`~typing.Optional`\[:class:`float`]
         The scale of the cosine distortion.
         This defaults to ``1.0``.
-    tan_offset: :data:`~typing.Optional`\\[:class:`float`]
+    tan_offset: :data:`~typing.Optional`\[:class:`float`]
         The offset of the tangent distortion.
         This defaults to ``0.0``.
-    tan_scale: :data:`~typing.Optional`\\[:class:`float`]
+    tan_scale: :data:`~typing.Optional`\[:class:`float`]
         The scale of the tangent distortion.
         This defaults to ``1.0``.
-    offset: :data:`~typing.Optional`\\[:class:`float`]
+    offset: :data:`~typing.Optional`\[:class:`float`]
         The offset of the distortion.
         This defaults to ``0.0``.
-    scale: :data:`~typing.Optional`\\[:class:`float`]
+    scale: :data:`~typing.Optional`\[:class:`float`]
         The scale of the distortion.
         This defaults to ``1.0``.
     """
@@ -376,7 +377,6 @@ class Distortion:
     @property
     def payload(self) -> DistortionPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: DistortionPayload = {}
 
         if self.sin_offset is not None:
@@ -407,6 +407,7 @@ class Distortion:
 
     @classmethod
     def from_payload(cls, payload: DistortionPayload) -> Self:
+        """Generate a :class:`Distortion` from a Lavalink payload."""
         return cls(
             sin_offset=payload.get("sinOffset"),
             sin_scale=payload.get("sinScale"),
@@ -421,22 +422,22 @@ class Distortion:
 
 @dataclass(unsafe_hash=True)
 class ChannelMix:
-    """Represents a filter which can be used to mix the audio channels.
+    r"""Represents a filter which can be used to mix the audio channels.
 
     Setting all of these to ``0.5`` will make the audio mono.
 
     Attributes
     ----------
-    left_to_left: :data:`~typing.Optional`\\[:class:`float`]
+    left_to_left: :data:`~typing.Optional`\[:class:`float`]
         The amount of the left channel to mix into the left channel.
         This defaults to ``1.0``.
-    left_to_right: :data:`~typing.Optional`\\[:class:`float`]
+    left_to_right: :data:`~typing.Optional`\[:class:`float`]
         The amount of the left channel to mix into the right channel.
         This defaults to ``0.0``.
-    right_to_left: :data:`~typing.Optional`\\[:class:`float`]
+    right_to_left: :data:`~typing.Optional`\[:class:`float`]
         The amount of the right channel to mix into the left channel.
         This defaults to ``0.0``.
-    right_to_right: :data:`~typing.Optional`\\[:class:`float`]
+    right_to_right: :data:`~typing.Optional`\[:class:`float`]
         The amount of the right channel to mix into the right channel.
         This defaults to ``1.0``.
     """
@@ -449,7 +450,6 @@ class ChannelMix:
     @property
     def payload(self) -> ChannelMixPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: ChannelMixPayload = {}
 
         if self.left_to_left is not None:
@@ -468,6 +468,7 @@ class ChannelMix:
 
     @classmethod
     def from_payload(cls, payload: ChannelMixPayload) -> Self:
+        """Generate a :class:`ChannelMix` from a Lavalink payload."""
         return cls(
             left_to_left=payload.get("leftToLeft"),
             left_to_right=payload.get("leftToRight"),
@@ -478,7 +479,7 @@ class ChannelMix:
 
 @dataclass(unsafe_hash=True)
 class LowPass:
-    """Represents a filter which can be used to apply a `low pass filter` to audio.
+    r"""Represents a filter which can be used to apply a `low pass filter` to audio.
 
     High frequencies are suppressed, while low frequencies are passed through.
 
@@ -486,7 +487,7 @@ class LowPass:
 
     Attributes
     ----------
-    smoothing: :data:`~typing.Optional`\\[:class:`float`]
+    smoothing: :data:`~typing.Optional`\[:class:`float`]
         The smoothing of the low pass filter.
         This defaults to ``0.0``.
     """
@@ -496,7 +497,6 @@ class LowPass:
     @property
     def payload(self) -> LowPassPayload:
         """Generate the raw Lavalink payload for this filter."""
-
         data: LowPassPayload = {}
 
         if self.smoothing is not None:
@@ -506,12 +506,13 @@ class LowPass:
 
     @classmethod
     def from_payload(cls, payload: LowPassPayload) -> Self:
+        """Generate a :class:`LowPass` from a Lavalink payload."""
         return cls(smoothing=payload.get("smoothing"))
 
 
 @dataclass(unsafe_hash=True)
 class Filter:
-    """Represents a filter which can be applied to audio.
+    r"""Represents a filter which can be applied to audio.
 
     .. container:: operations
 
@@ -533,25 +534,25 @@ class Filter:
 
     Attributes
     ----------
-    equalizer: :data:`~typing.Optional`\\[:class:`Equalizer`]
+    equalizer: :data:`~typing.Optional`\[:class:`Equalizer`]
         The equalizer to use.
-    karaoke: :data:`~typing.Optional`\\[:class:`Karaoke`]
+    karaoke: :data:`~typing.Optional`\[:class:`Karaoke`]
         The karaoke filter to use.
-    timescale: :data:`~typing.Optional`\\[:class:`Timescale`]
+    timescale: :data:`~typing.Optional`\[:class:`Timescale`]
         The timescale filter to use.
-    tremolo: :data:`~typing.Optional`\\[:class:`Tremolo`]
+    tremolo: :data:`~typing.Optional`\[:class:`Tremolo`]
         The tremolo filter to use.
-    vibrato: :data:`~typing.Optional`\\[:class:`Vibrato`]
+    vibrato: :data:`~typing.Optional`\[:class:`Vibrato`]
         The vibrato filter to use.
-    rotation: :data:`~typing.Optional`\\[:class:`Rotation`]
+    rotation: :data:`~typing.Optional`\[:class:`Rotation`]
         The rotation filter to use.
-    distortion: :data:`~typing.Optional`\\[:class:`Distortion`]
+    distortion: :data:`~typing.Optional`\[:class:`Distortion`]
         The distortion filter to use.
-    channel_mix: :data:`~typing.Optional`\\[:class:`ChannelMix`]
+    channel_mix: :data:`~typing.Optional`\[:class:`ChannelMix`]
         The channel mix filter to use.
-    low_pass: :data:`~typing.Optional`\\[:class:`LowPass`]
+    low_pass: :data:`~typing.Optional`\[:class:`LowPass`]
         The low pass filter to use.
-    volume: :data:`~typing.Optional`\\[:class:`float`]
+    volume: :data:`~typing.Optional`\[:class:`float`]
         The volume to use.
     """
 
@@ -569,7 +570,6 @@ class Filter:
     @property
     def payload(self) -> Filters:
         """Generate the raw Lavalink payload for this filter."""
-
         payload: Filters = {}
 
         if self.equalizer:
@@ -607,7 +607,6 @@ class Filter:
     @classmethod
     def from_payload(cls, data: Filters) -> Self:
         """Generate a filter from a raw Lavalink payload."""
-
         self = cls()
 
         if "equalizer" in data:
@@ -643,8 +642,7 @@ class Filter:
         return self
 
     def __or__(self, other: Any) -> Filter:
-        # A | B uses A and replaces B, like dictionaries.
-
+        """Merge two filters together, favouring attributes from other."""
         if not isinstance(other, Filter):
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
@@ -662,8 +660,7 @@ class Filter:
         )
 
     def __ior__(self, other: Any) -> None:
-        # Like __or__ but |=
-
+        """Merge two filters together, favouring attributes from other, in place."""
         if not isinstance(other, Filter):
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
@@ -679,8 +676,7 @@ class Filter:
         self.volume = other.volume or self.volume
 
     def __and__(self, other: Any) -> Filter:
-        # A & B uses A and only B if A does not have that field.
-
+        """Merge two filters together, favouring attributes from self."""
         if not isinstance(other, Filter):
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 
@@ -698,8 +694,7 @@ class Filter:
         )
 
     def __iand__(self, other: Any) -> None:
-        # Like __and__ but &=
-
+        """Merge two filters together, favouring attributes from self, in place."""
         if not isinstance(other, Filter):
             raise TypeError(f"Expected Filter instance, not {type(other)!r}")
 

--- a/mafic/ip.py
+++ b/mafic/ip.py
@@ -1,3 +1,4 @@
+"""The Lavalink route planner API."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -117,11 +118,11 @@ class FailingAddress:
 
 
 class BaseIPRoutePlannerStatus(ABC):
-    """An :term:`abstract base class` representing the status of an IP route planner.
+    r"""An :term:`abstract base class` representing the status of an IP route planner.
 
     Attributes
     ----------
-    failing_addresses: :class:`list`\\[:class:`FailingAddress`]
+    failing_addresses: :class:`list`\[:class:`FailingAddress`]
         The list of failing addresses.
     ip_block: :class:`IPBlock`
         The IP block.
@@ -141,11 +142,11 @@ class BaseIPRoutePlannerStatus(ABC):
 
 
 class RotatingIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
-    """Represents the status of a rotating IP route planner.
+    r"""Represents the status of a rotating IP route planner.
 
     Attributes
     ----------
-    type: :data:`~typing.Literal`\\[:attr:`IPRoutePlannerType.ROTATING_IP`]
+    type: :data:`~typing.Literal`\[:attr:`IPRoutePlannerType.ROTATING_IP`]
         The type of route planner. This will always be
         :attr:`IPRoutePlannerType.ROTATING_IP`.
     current_address: :class:`str`
@@ -168,11 +169,11 @@ class RotatingIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
 
 
 class NanoIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
-    """Represents the status of a nano IP route planner.
+    r"""Represents the status of a nano IP route planner.
 
     Attributes
     ----------
-    type: :data:`~typing.Literal`\\[:attr:`IPRoutePlannerType.NANO_IP`]
+    type: :data:`~typing.Literal`\[:attr:`IPRoutePlannerType.NANO_IP`]
         The type of route planner. This will always be
         :attr:`IPRoutePlannerType.NANO_IP`.
     current_address_index: :class:`int`
@@ -189,11 +190,11 @@ class NanoIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
 
 
 class RotatingNanoIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
-    """Represents the status of a rotating nano IP route planner.
+    r"""Represents the status of a rotating nano IP route planner.
 
     Attributes
     ----------
-    type: :data:`~typing.Literal`\\[:attr:`IPRoutePlannerType.ROTATING_NANO_IP`]
+    type: :data:`~typing.Literal`\[:attr:`IPRoutePlannerType.ROTATING_NANO_IP`]
         The type of route planner. This will always be
         :attr:`IPRoutePlannerType.ROTATING_NANO_IP`.
     block_index: :class:`int`
@@ -213,11 +214,11 @@ class RotatingNanoIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
 
 
 class BalancingIPRoutePlannerStatus(BaseIPRoutePlannerStatus):
-    """Represents the status of a balancing IP route planner.
+    r"""Represents the status of a balancing IP route planner.
 
     Attributes
     ----------
-    type: :data:`~typing.Literal`\\[:attr:`IPRoutePlannerType.BALANCING_IP`]
+    type: :data:`~typing.Literal`\[:attr:`IPRoutePlannerType.BALANCING_IP`]
         The type of route planner. This will always be
         :attr:`IPRoutePlannerType.BALANCING_IP`.
     current_address_index: :class:`int`

--- a/mafic/ip.py
+++ b/mafic/ip.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Union
 
@@ -114,7 +114,9 @@ class FailingAddress:
 
     def __init__(self, data: FailingIPAddress) -> None:
         self.address: str = data["address"]
-        self.time: datetime = datetime.fromtimestamp(data["failingTimestamp"])
+        self.time: datetime = datetime.fromtimestamp(
+            data["failingTimestamp"], tz=timezone.utc
+        )
 
 
 class BaseIPRoutePlannerStatus(ABC):

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -538,10 +538,11 @@ class Node(Generic[ClientT]):
         )
         try:
             await self._connect_to_websocket(headers=headers, session=session)
-        except Exception:
+        except Exception as e:  # noqa: BLE001
             _log.error(
-                "Failed to connect to lavalink at %s",
+                "Failed to connect to lavalink at %s: %s",
                 self._rest_uri,
+                e,
                 extra={"label": self._label},
             )
             print_exc()

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -1,3 +1,4 @@
+"""Node class to represent one Lavalink instance."""
 # SPDX-License-Identifier: MIT
 # pyright: reportImportCycles=false
 # Player import.
@@ -70,7 +71,7 @@ __all__ = ("Node",)
 def _wrap_regions(
     regions: Sequence[Group | Region | VoiceRegion] | None,
 ) -> list[VoiceRegion] | None:
-    """Converts a list of voice regions, regions and groups into a list of regions.
+    r"""Convert a list of voice regions, regions and groups into a list of regions.
 
     Parameters
     ----------
@@ -79,10 +80,9 @@ def _wrap_regions(
 
     Returns
     -------
-    :class:`list`\\[:class:`Region`] | None
+    :class:`list`\[:class:`Region`] | None
         The converted list of regions.
     """
-
     if not regions:
         return None
 
@@ -107,7 +107,7 @@ def _wrap_regions(
 
 
 class Node(Generic[ClientT]):
-    """Represents a Lavalink node.
+    r"""Represents a Lavalink node.
 
     .. warning::
 
@@ -134,7 +134,7 @@ class Node(Generic[ClientT]):
     timeout:
         The amount of time the node will wait for a response before raising a timeout
         error.
-    session: :data:`~typing.Optional`\\[:class:`aiohttp.ClientSession`]
+    session: :data:`~typing.Optional`\[:class:`aiohttp.ClientSession`]
         The session to use for the node.
         If not provided, a new session will be created.
     resume_key:
@@ -149,10 +149,10 @@ class Node(Generic[ClientT]):
 
     Attributes
     ----------
-    regions: :data:`~typing.Optional`\\[:class:`list`\\[:class:`~.VoiceRegion`]]
+    regions: :data:`~typing.Optional`\[:class:`list`\[:class:`~.VoiceRegion`]]
         The regions that the node can be used in.
         This is used to determine when to use this node.
-    shard_ids: :data:`~typing.Optional`\\[:class:`list`\\[:class:`int`]]
+    shard_ids: :data:`~typing.Optional`\[:class:`list`\[:class:`int`]]
         The shard IDs that the node can be used in.
         This is used to determine when to use this node.
     """
@@ -229,31 +229,26 @@ class Node(Generic[ClientT]):
     @property
     def host(self) -> str:
         """The host of the node."""
-
         return self._host
 
     @property
     def port(self) -> int:
         """The port of the node."""
-
         return self._port
 
     @property
     def label(self) -> str:
         """The label of the node."""
-
         return self._label
 
     @property
     def client(self) -> ClientT:
         """The client that the node is attached to."""
-
         return self._client
 
     @property
     def secure(self) -> bool:
         """Whether the node is using a secure connection."""
-
         return self._secure
 
     @property
@@ -272,7 +267,6 @@ class Node(Generic[ClientT]):
 
         This is ``False`` if the node is not connected, or if it is not ready.
         """
-
         return self._available
 
     @property
@@ -295,7 +289,6 @@ class Node(Generic[ClientT]):
         This is so that the node will be used if it is the only one available,
         or if stats sending is disabled on the node.
         """
-
         if self._stats is None:
             # Stats haven't been set yet, so we'll just return a high value.
             # This is so we can properly balance known nodes.
@@ -364,11 +357,10 @@ class Node(Generic[ClientT]):
 
             This is now a list.
         """
-
         return [*self._players.values()]
 
     def get_player(self, guild_id: int) -> Player[ClientT] | None:
-        """Get a player from the node.
+        r"""Get a player from the node.
 
         Parameters
         ----------
@@ -377,10 +369,9 @@ class Node(Generic[ClientT]):
 
         Returns
         -------
-        :data:`~typing.Optional`\\[:class:`Player`]
+        :data:`~typing.Optional`\[:class:`Player`]
             The player for the guild, if found.
         """
-
         return self._players.get(guild_id)
 
     def add_player(self, guild_id: int, player: Player[ClientT]) -> None:
@@ -393,7 +384,6 @@ class Node(Generic[ClientT]):
         player:
             The player to add.
         """
-
         self._players[guild_id] = player
 
     def remove_player(self, guild_id: int) -> None:
@@ -409,7 +399,6 @@ class Node(Generic[ClientT]):
         guild_id:
             The guild ID to remove the player for.
         """
-
         self._players.pop(guild_id, None)
 
     async def _check_version(self) -> None:
@@ -430,7 +419,6 @@ class Node(Generic[ClientT]):
             If the minor version is greater than 7.
             Some features may not work.
         """
-
         if self._rest_uri.path.endswith("/v3") or self._ws_uri.path.endswith(
             "/websocket"
         ):
@@ -483,7 +471,6 @@ class Node(Generic[ClientT]):
         session:
             The session to use for the websocket connection.
         """
-
         try:
             self._ws = (
                 await session.ws_connect(  # pyright: ignore[reportUnknownMemberType]
@@ -520,7 +507,6 @@ class Node(Generic[ClientT]):
             If the connection times out.
             You can change the timeout with the `timeout` parameter.
         """
-
         if self._ws is not None:
             raise NodeAlreadyConnected()
 
@@ -597,7 +583,6 @@ class Node(Generic[ClientT]):
 
     async def _ws_listener(self) -> None:
         """Listen for messages from the websocket."""
-
         backoff = ExponentialBackoff()
 
         if self._ws is None:
@@ -654,7 +639,6 @@ class Node(Generic[ClientT]):
         data:
             The data to handle.
         """
-
         _log.debug("Received event with op %s", data["op"])
         _log.debug("Event data: %s", data)
 
@@ -712,7 +696,6 @@ class Node(Generic[ClientT]):
         data:
             The data to handle.
         """
-
         if not (player := self.get_player(int(data["guildId"]))):
             _log.error(
                 "Could not find player for guild %s, discarding event.", data["guildId"]
@@ -743,7 +726,6 @@ class Node(Generic[ClientT]):
         :exc:`ValueError`
             If the endpoint in the payload is ``None``.
         """
-
         _log.debug(
             "Sending player update to lavalink.",
             extra={"label": self._label, "guild": guild_id},
@@ -765,7 +747,6 @@ class Node(Generic[ClientT]):
 
     def configure_resuming(self) -> Coro[None]:
         """Configure the node to resume."""
-
         _log.info(
             "Sending resume configuration to lavalink with resume key %s.",
             self._resume_key,
@@ -789,7 +770,6 @@ class Node(Generic[ClientT]):
         guild_id:
             The guild ID to destroy the player for.
         """
-
         _log.debug("Sending request to destroy player", extra={"label": self._label})
 
         return self.__request(
@@ -830,7 +810,6 @@ class Node(Generic[ClientT]):
         filter:
             The filter to apply to the player.
         """
-
         data: UpdatePlayerPayload = {}
 
         if track is not MISSING:
@@ -871,7 +850,6 @@ class Node(Generic[ClientT]):
 
     async def _create_session(self) -> aiohttp.ClientSession:
         """Create a new session for the node."""
-
         return aiohttp.ClientSession(json_serialize=dumps)
 
     async def __request(
@@ -899,7 +877,6 @@ class Node(Generic[ClientT]):
         :data:`~typing.Any`
             The JSON response from the node.
         """
-
         if self.__session is None:
             self.__session = await self._create_session()
 
@@ -947,7 +924,7 @@ class Node(Generic[ClientT]):
     async def fetch_tracks(
         self, query: str, *, search_type: str
     ) -> list[Track] | Playlist | None:
-        """Fetch tracks from the node.
+        r"""Fetch tracks from the node.
 
         Parameters
         ----------
@@ -958,14 +935,13 @@ class Node(Generic[ClientT]):
 
         Returns
         -------
-        :class:`list`\\[:class:`Track`]
+        :class:`list`\[:class:`Track`]
             A list of tracks if the load type is ``TRACK_LOADED`` or ``SEARCH_RESULT``.
         :class:`Playlist`
             A playlist if the load type is ``PLAYLIST_LOADED``.
         None
             If the load type is ``NO_MATCHES``.
         """
-
         if not URL_REGEX.match(query):
             query = f"{search_type}:{query}"
 
@@ -1003,7 +979,6 @@ class Node(Generic[ClientT]):
         --------
         :meth:`decode_tracks`
         """
-
         info: TrackInfo = await self.__request(
             "GET", "decodetrack", params={"encodedTrack": track}
         )
@@ -1011,7 +986,7 @@ class Node(Generic[ClientT]):
         return Track.from_data(track=track, info=info)
 
     async def decode_tracks(self, tracks: list[str]) -> list[Track]:
-        """Decode a list of tracks from the encoded base64 data.
+        r"""Decode a list of tracks from the encoded base64 data.
 
         Parameters
         ----------
@@ -1020,14 +995,13 @@ class Node(Generic[ClientT]):
 
         Returns
         -------
-        :class:`list`\\[:class:`Track`]
+        :class:`list`\[:class:`Track`]
             The decoded tracks.
 
         See Also
         --------
         :meth:`decode_track`
         """
-
         track_data: list[TrackWithInfo] = await self.__request(
             "POST", "decodetracks", json=tracks
         )
@@ -1035,14 +1009,13 @@ class Node(Generic[ClientT]):
         return [Track.from_data_with_info(track) for track in track_data]
 
     async def fetch_plugins(self) -> list[Plugin]:
-        """Fetch the plugins from the node.
+        r"""Fetch the plugins from the node.
 
         Returns
         -------
-        :class:`list`\\[:class:`Plugin`]
+        :class:`list`\[:class:`Plugin`]
             The plugins from the node.
         """
-
         plugins: list[PluginData] = await self.__request("GET", "plugins")
 
         return [Plugin(plugin) for plugin in plugins]
@@ -1055,7 +1028,6 @@ class Node(Generic[ClientT]):
         :data:`.RoutePlannerStatus`
             The route planner status from the node.
         """
-
         data: RoutePlannerStatusPayload = await self.__request(
             "GET", "routeplanner/status"
         )
@@ -1087,14 +1059,12 @@ class Node(Generic[ClientT]):
         address:
             The address to unmark.
         """
-
         await self.__request(
             "POST", "routeplanner/free/address", json={"address": address}
         )
 
     async def unmark_all_addresses(self) -> None:
         """Unmark all failed addresses so they can be used again."""
-
         await self.__request("POST", "routeplanner/free/all")
 
     async def _add_unknown_player(self, player_id: int, state: PlayerPayload) -> None:
@@ -1107,7 +1077,6 @@ class Node(Generic[ClientT]):
         state:
             The state of the player.
         """
-
         guild = self.client.get_guild(player_id)
         if guild is None:
             guild = await self.client.fetch_guild(player_id)
@@ -1139,7 +1108,6 @@ class Node(Generic[ClientT]):
         player_id:
             The guild ID of the player.
         """
-
         await self._players[player_id].disconnect(force=True)
         self.remove_player(player_id)
 
@@ -1151,7 +1119,6 @@ class Node(Generic[ClientT]):
             This method is called automatically when the client is ready.
             You should not need to call this method yourself.
         """
-
         players: list[PlayerPayload] = await self.__request(
             "GET", f"sessions/{self._session_id}/players"
         )

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -506,7 +506,7 @@ class Node(Generic[ClientT]):
             You can change the timeout with the `timeout` parameter.
         """
         if self._ws is not None:
-            raise NodeAlreadyConnected()
+            raise NodeAlreadyConnected
 
         _log.info("Waiting for client to be ready...", extra={"label": self._label})
         await self._client.wait_until_ready()
@@ -962,6 +962,7 @@ class Node(Generic[ClientT]):
             raise TrackLoadException.from_data(data["exception"])
         else:
             _log.warning("Unknown load type recieved: %s", data["loadType"])
+            return None
 
     async def decode_track(self, track: str) -> Track:
         """Decode a track from the encoded base64 data.

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -513,7 +513,8 @@ class Node(Generic[ClientT]):
 
         _log.info("Waiting for client to be ready...", extra={"label": self._label})
         await self._client.wait_until_ready()
-        assert self._client.user is not None
+        if self._client.user is None:
+            raise RuntimeError("Client.user is None")
 
         if self.__session is None:
             self.__session = await self._create_session()

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -859,7 +859,7 @@ class Node(Generic[ClientT]):
         path: str,
         json: OutgoingMessage | None = None,
         params: OutgoingParams | None = None,
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401
         """Send a request to the node.
 
         Parameters
@@ -897,7 +897,7 @@ class Node(Generic[ClientT]):
             json=json,
             params=params,
             headers={"Authorization": self.__password},
-        ) as resp:
+        ) as resp:  # noqa: ANN401
             _log.debug("Received status %s from lavalink.", resp.status)
             if resp.status == 204:
                 return None

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -100,9 +100,8 @@ def _wrap_regions(
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
             actual_regions.append(item)
         else:
-            raise TypeError(
-                f"Expected Group, Region, or VoiceRegion, got {type(item)!r}."
-            )
+            msg = f"Expected Group, Region, or VoiceRegion, got {type(item)!r}."
+            raise TypeError(msg)
 
     return actual_regions
 
@@ -446,13 +445,11 @@ class Node(Generic[ClientT]):
                 minor = int(minor)
 
                 if major != 3:
-                    raise RuntimeError(
-                        f"Unsupported lavalink version {version} (expected 3.7.x)"
-                    )
+                    msg = f"Unsupported lavalink version {version} (expected 3.7.x)"
+                    raise RuntimeError(msg)
                 elif minor < 7:
-                    raise RuntimeError(
-                        f"Unsupported lavalink version {version} (expected 3.7.x)"
-                    )
+                    msg = f"Unsupported lavalink version {version} (expected 3.7.x)"
+                    raise RuntimeError(msg)
                 elif minor > 7:
                     message = UnsupportedVersionWarning.message
                     warnings.warn(message, UnsupportedVersionWarning)
@@ -514,7 +511,8 @@ class Node(Generic[ClientT]):
         _log.info("Waiting for client to be ready...", extra={"label": self._label})
         await self._client.wait_until_ready()
         if self._client.user is None:
-            raise RuntimeError("Client.user is None")
+            msg = "Client.user is None"
+            raise RuntimeError(msg)
 
         if self.__session is None:
             self.__session = await self._create_session()
@@ -593,9 +591,8 @@ class Node(Generic[ClientT]):
                 "No websocket was found, aborting listener.",
                 extra={"label": self._label},
             )
-            raise RuntimeError(
-                "Websocket is not connected but attempted to listen, report this."
-            )
+            msg = "Websocket is not connected but attempted to listen, report this."
+            raise RuntimeError(msg)
 
         # To catch closing messages, we cannot use async for.
         while True:
@@ -734,7 +731,8 @@ class Node(Generic[ClientT]):
             extra={"label": self._label, "guild": guild_id},
         )
         if data["endpoint"] is None:
-            raise ValueError("Discord did not provide an endpoint.")
+            msg = "Discord did not provide an endpoint."
+            raise ValueError(msg)
 
         return self.__request(
             "PATCH",
@@ -1052,7 +1050,8 @@ class Node(Generic[ClientT]):
         elif data["class"] is None:
             return None
         else:
-            raise RuntimeError(f"Unknown route planner class {data['class']}.")
+            msg = f"Unknown route planner class {data['class']}."
+            raise RuntimeError(msg)
 
     async def unmark_failed_address(self, address: str) -> None:
         """Unmark a failed address so it can be used again.

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -35,7 +35,8 @@ from .warnings import *
 
 if TYPE_CHECKING:
     from asyncio import Task
-    from typing import Any, Literal, Sequence
+    from collections.abc import Sequence
+    from typing import Any, Literal
 
     from aiohttp import ClientWebSocketResponse
 

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -444,10 +444,7 @@ class Node(Generic[ClientT]):
                 major = int(major)
                 minor = int(minor)
 
-                if major != 3:
-                    msg = f"Unsupported lavalink version {version} (expected 3.7.x)"
-                    raise RuntimeError(msg)
-                elif minor < 7:
+                if major != 3 or minor < 7:
                     msg = f"Unsupported lavalink version {version} (expected 3.7.x)"
                     raise RuntimeError(msg)
                 elif minor > 7:

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -149,7 +149,7 @@ class Node(Generic[ClientT]):
 
     Attributes
     ----------
-    regions: :data:`~typing.Optional`\\[:class:`list`\\[:class:`~mafic.region.VoiceRegion`]]
+    regions: :data:`~typing.Optional`\\[:class:`list`\\[:class:`~.VoiceRegion`]]
         The regions that the node can be used in.
         This is used to determine when to use this node.
     shard_ids: :data:`~typing.Optional`\\[:class:`list`\\[:class:`int`]]

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING, Generic, cast
 import aiohttp
 import yarl
 
-from mafic.typings.http import TrackWithInfo
-
 from .__libraries import MISSING, ExponentialBackoff, dumps, loads
 from .errors import *
 from .ip import (
@@ -31,6 +29,13 @@ from .region import Group, Region, VoiceRegion
 from .stats import NodeStats
 from .track import Track
 from .type_variables import ClientT
+from .typings import (
+    BalancingIPRouteDetails,
+    NanoIPRouteDetails,
+    RotatingIPRouteDetails,
+    RotatingNanoIPRouteDetails,
+    TrackWithInfo,
+)
 from .warnings import *
 
 if TYPE_CHECKING:
@@ -45,17 +50,13 @@ if TYPE_CHECKING:
     from .ip import RoutePlannerStatus
     from .player import Player
     from .typings import (
-        BalancingIPRouteDetails,
         Coro,
         EventPayload,
         IncomingMessage,
-        NanoIPRouteDetails,
         OutgoingMessage,
         OutgoingParams,
         Player as PlayerPayload,
         PluginData,
-        RotatingIPRouteDetails,
-        RotatingNanoIPRouteDetails,
         RoutePlannerStatus as RoutePlannerStatusPayload,
         TrackInfo,
         TrackLoadingResult,

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -1,3 +1,4 @@
+"""A Player is used to connect to a channel."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -107,7 +108,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
             This is used internally to set the state of the player.
             You should not need to use this.
         """
-
         self._session_id = state["voice"]["sessionId"]
         self._ping = state["voice"]["ping"]
         self._current = (
@@ -124,6 +124,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
             self._position = state["track"]["info"]["position"]
 
     def __repr__(self) -> str:
+        """Return a string representation of the player."""
         attrs = (
             ("guild_id", self._guild_id),
             ("session_id", self._session_id),
@@ -137,13 +138,11 @@ class Player(VoiceProtocol, Generic[ClientT]):
     @property
     def connected(self) -> bool:
         """Whether the player is connected to a voice channel."""
-
         return self._connected
 
     @property
     def position(self) -> int:
         """The current position of the player in milliseconds."""
-
         pos = self._position
 
         if self._connected and self._current is not None:
@@ -158,13 +157,11 @@ class Player(VoiceProtocol, Generic[ClientT]):
     @property
     def ping(self) -> int:
         """The current ping of the player in milliseconds."""
-
         return self._ping
 
     @property
     def node(self) -> Node[ClientT]:
         """The node that the player is connected to."""
-
         if self._node is None:
             _log.warning(
                 "Unable to use best node, player not connected, finding random node.",
@@ -177,13 +174,11 @@ class Player(VoiceProtocol, Generic[ClientT]):
     @property
     def current(self) -> Track | None:
         """The current track that is playing."""
-
         return self._current
 
     @property
     def paused(self) -> bool:
         """Whether the player is paused."""
-
         return self._paused
 
     def update_state(self, state: PlayerUpdateState) -> None:
@@ -196,7 +191,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         state:
             The state to update the player with.
         """
-
         self._last_update = state["time"]
         self._position = state.get("position", 0)
         self._connected = state["connected"]
@@ -208,12 +202,10 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         This is an alias for :attr:`connected`.
         """
-
         return self._connected
 
     async def _dispatch_player_update(self) -> None:
         """Dispatch a player update to the node."""
-
         if self._node is None:
             _log.debug("Recieved voice update before node was found.")
             return
@@ -233,6 +225,15 @@ class Player(VoiceProtocol, Generic[ClientT]):
         )
 
     def dispatch_event(self, data: EventPayload) -> None:
+        """Dispatch an event to the player.
+
+        This is called by the library and usually should not be called by the user.
+
+        Parameters
+        ----------
+        data:
+            The event payload to dispatch.
+        """
         if data["type"] == "WebSocketClosedEvent":
             event = WebSocketClosedEvent(payload=data, player=self)
             _log.debug("Received websocket closed event: %s", event)
@@ -307,7 +308,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         data:
             The voice state update payload.
         """
-
         before_session_id = self._session_id
         self._session_id = data["session_id"]
 
@@ -336,7 +336,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         data:
             The voice server update payload.
         """
-
         # Fetch the best node as we either don't know the best one yet.
         # Or the node we were using was not the best one (endpoint optimisation).
         if (
@@ -384,7 +383,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         self_deaf:
             Whether to deafen the bot on connect.
         """
-
         if not isinstance(self.channel, (VoiceChannel, StageChannel)):
             raise TypeError("Voice channel must be a VoiceChannel or StageChannel.")
 
@@ -406,7 +404,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         force:
             Whether to force the disconnect even if not connected.
         """
-
         if not self._connected and not force:
             return
 
@@ -429,7 +426,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         This shouldn't be called directly. Instead, use :meth:`disconnect`.
         """
-
         self._current = None
         self._position = 0
         self._paused = False
@@ -444,7 +440,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         This will disconnect the player and remove it from the node.
         """
-
         _log.debug(
             "Disconnecting player and destroying client.",
             extra={"guild": self._guild_id},
@@ -458,7 +453,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
     async def fetch_tracks(
         self, query: str, search_type: SearchType | str = SearchType.YOUTUBE
     ) -> list[Track] | Playlist | None:
-        """Fetch tracks from the node.
+        r"""Fetch tracks from the node.
 
         Parameters
         ----------
@@ -469,7 +464,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         Returns
         -------
-        :class:`list`\\[:class:`Track`]
+        :class:`list`\[:class:`Track`]
             A list of tracks if the load type is ``TRACK_LOADED`` or ``SEARCH_RESULT``.
         :class:`Playlist`
             A playlist if the load type is ``PLAYLIST_LOADED``.
@@ -481,7 +476,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         If a node was not selected due to not being connected, this will use a
         random node.
         """
-
         node = self.node
 
         raw_type: str
@@ -527,7 +521,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         PlayerNotConnected
             If the player is not connected to a voice channel.
         """
-
         if self._node is None or not self._connected:
             raise PlayerNotConnected
 
@@ -588,7 +581,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         -----
         This is a convenience method for :meth:`update`.
         """
-
         return await self.update(
             track=track,
             position=start_time,
@@ -615,7 +607,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         -----
         This is a convenience method for :meth:`update`.
         """
-
         return await self.update(pause=pause)
 
     async def resume(self) -> None:
@@ -631,7 +622,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         This is a convenience method for :meth:`pause`, with ``pause`` set to
         ``False``.
         """
-
         return await self.pause(False)
 
     async def stop(self) -> None:
@@ -646,7 +636,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         -----
         This is a convenience method for :meth:`update`.
         """
-
         await self.update(track=None, replace=True)
 
     async def _update_filters(self, *, fast_apply: bool) -> None:
@@ -657,7 +646,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         fast_apply:
             Whether to seek to the current position after updating the filters.
         """
-
         await self.update(
             filter=reduce(or_, self._filters.values()) if self._filters else Filter()
         )
@@ -687,7 +675,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         PlayerNotConnected
             If the player is not connected to a voice channel.
         """
-
         self._filters[label] = filter
 
         await self._update_filters(fast_apply=fast_apply)
@@ -711,7 +698,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         ValueError
             If the filter does not exist.
         """
-
         self._filters.pop(label)
 
         await self._update_filters(fast_apply=fast_apply)
@@ -731,7 +717,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         PlayerNotConnected
             If the player is not connected to a voice channel.
         """
-
         self._filters.clear()
 
         await self._update_filters(fast_apply=fast_apply)
@@ -753,7 +738,6 @@ class Player(VoiceProtocol, Generic[ClientT]):
         -----
         This is a convenience method for :meth:`update`.
         """
-
         await self.update(volume=volume)
 
     async def seek(self, position: int, /) -> None:
@@ -773,5 +757,4 @@ class Player(VoiceProtocol, Generic[ClientT]):
         -----
         This is a convenience method for :meth:`update`.
         """
-
         return await self.update(position=position)

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -593,7 +593,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
             pause=pause,
         )
 
-    async def pause(self, pause: bool = True) -> None:
+    async def pause(self, pause: bool = True) -> None:  # noqa: FBT
         """Pause the current track.
 
         Parameters
@@ -625,7 +625,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
         This is a convenience method for :meth:`pause`, with ``pause`` set to
         ``False``.
         """
-        return await self.pause(False)
+        return await self.pause(False)  # noqa: FBT003
 
     async def stop(self) -> None:
         """Stop the current track.

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -20,7 +20,6 @@ from .__libraries import (
 from .errors import NoNodesAvailable, PlayerNotConnected
 from .events import *
 from .filter import Filter
-from .playlist import Playlist
 from .pool import NodePool
 from .search_type import SearchType
 from .track import Track
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
         VoiceServerUpdatePayload,
     )
     from .node import Node
+    from .playlist import Playlist
     from .typings import EventPayload, Player as PlayerPayload, PlayerUpdateState
 
 

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -81,7 +81,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
         self.channel: Connectable = channel
 
         if not isinstance(self.channel, GuildChannel):
-            raise TypeError("Voice channel must be a GuildChannel.")
+            msg = "Voice channel must be a GuildChannel."
+            raise TypeError(msg)
 
         self.guild: Guild = self.channel.guild
 
@@ -320,9 +321,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         channel = self.guild.get_channel(int(channel_id))
         if not isinstance(channel, (VoiceChannel, StageChannel)):
-            raise TypeError(
-                "Channel was not a connectable channel that was recognised."
-            )
+            msg = "Channel was not a connectable channel that was recognised."
+            raise TypeError(msg)
 
         self.channel = channel
 
@@ -387,7 +387,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
             Whether to deafen the bot on connect.
         """
         if not isinstance(self.channel, (VoiceChannel, StageChannel)):
-            raise TypeError("Voice channel must be a VoiceChannel or StageChannel.")
+            msg = "Voice channel must be a VoiceChannel or StageChannel."
+            raise TypeError(msg)
 
         if not NodePool.nodes:
             raise NoNodesAvailable

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -149,7 +149,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
             # Add the time since the last update to the position.
             # If the track total time is less than that, use that.
             pos = min(
-                self._current.length, pos + int(((time() * 1000) - self._last_update))
+                self._current.length, pos + int((time() * 1000) - self._last_update)
             )
 
         return pos

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -319,7 +319,10 @@ class Player(VoiceProtocol, Generic[ClientT]):
             return self.cleanup()
 
         channel = self.guild.get_channel(int(channel_id))
-        assert isinstance(channel, (StageChannel, VoiceChannel))
+        if not isinstance(channel, (VoiceChannel, StageChannel)):
+            raise TypeError(
+                "Channel was not a connectable channel that was recognised."
+            )
 
         self.channel = channel
 

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -326,8 +326,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         self.channel = channel
 
-        if self._session_id != before_session_id:
-            await self._dispatch_player_update()
+        if self._session_id != before_session_id:  # noqa: RET503
+            await self._dispatch_player_update()  # noqa: RET503
 
     async def on_voice_server_update(self, data: VoiceServerUpdatePayload) -> None:
         """Handle a voice server update.

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -270,7 +270,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
             if track is None:
                 _log.error(
-                    "Received track exception event but no track was playing, discarding."
+                    "Received track exception event but no track was playing, "
+                    "discarding."
                 )
                 return
 
@@ -313,7 +314,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
         channel_id = data["channel_id"]
 
         if channel_id is None:  # pyright: ignore[reportUnnecessaryComparison]
-            # This can happen and is on disconnect, not sure why this is typed as always Snowflake.
+            # This can happen and is on disconnect.
+            # Not sure why this is typed as always Snowflake.
             return self.cleanup()
 
         channel = self.guild.get_channel(int(channel_id))

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -366,8 +366,8 @@ class Player(VoiceProtocol, Generic[ClientT]):
     async def connect(
         self,
         *,
-        timeout: float,
-        reconnect: bool,
+        timeout: float,  # noqa: ARG002
+        reconnect: bool,  # noqa: ARG002
         self_mute: bool = False,
         self_deaf: bool = False,
     ) -> None:

--- a/mafic/playlist.py
+++ b/mafic/playlist.py
@@ -28,7 +28,7 @@ class Playlist:
 
     __slots__ = ("name", "selected_track", "tracks")
 
-    def __init__(self, *, info: PlaylistInfo, tracks: list[TrackWithInfo]):
+    def __init__(self, *, info: PlaylistInfo, tracks: list[TrackWithInfo]) -> None:
         self.name: str = info["name"]
         self.selected_track: int = info["selectedTrack"]
         self.tracks: list[Track] = [

--- a/mafic/playlist.py
+++ b/mafic/playlist.py
@@ -1,3 +1,4 @@
+"""The module containing :class:`Playlist`."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ __all__ = ("Playlist",)
 
 
 class Playlist:
-    """Represents a playlist.
+    r"""Represents a playlist.
 
     Attributes
     ----------
@@ -21,7 +22,7 @@ class Playlist:
         The name of the playlist.
     selected_track: :class:`int`
         The index of the selected track, if any.
-    tracks: :class:`list`\\[:class:`Track`]
+    tracks: :class:`list`\[:class:`Track`]
         A list of tracks in the playlist.
     """
 

--- a/mafic/plugin.py
+++ b/mafic/plugin.py
@@ -1,3 +1,4 @@
+"""The Lavalink plugin system."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/mafic/pool.py
+++ b/mafic/pool.py
@@ -1,3 +1,4 @@
+r"""A module containing a :class:`NodePool`, used to manage :class:`Node`\s."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -85,14 +86,12 @@ class NodePool(Generic[ClientT]):
 
     @classproperty
     def label_to_node(cls) -> dict[str, Node[ClientT]]:
-        """A dictionary mapping node labels to nodes."""
-
+        """Get a mapping node labels to nodes."""
         return cls._nodes
 
     @classproperty
     def nodes(cls) -> list[Node[ClientT]]:
-        """A list of all nodes."""
-
+        """Get the list of all nodes."""
         return list(cls._nodes.values())
 
     async def create_node(
@@ -110,7 +109,7 @@ class NodePool(Generic[ClientT]):
         regions: Sequence[Group | Region | VoiceRegion] | None = None,
         shard_ids: Sequence[int] | None = None,
     ) -> Node[ClientT]:
-        """Create a node and connect it.
+        r"""Create a node and connect it.
 
         The parameters here relate to :class:`Node`.
 
@@ -130,7 +129,7 @@ class NodePool(Generic[ClientT]):
             The interval to send heartbeats to the node websocket connection.
         timeout:
             The timeout to use for the node websocket connection.
-        session: :data:`~typing.Optional`\\ [:class:`aiohttp.ClientSession`]
+        session: :data:`~typing.Optional`\[:class:`aiohttp.ClientSession`]
             The session to use for the node websocket connection.
         resume_key:
             The key to use to resume the node websocket connection.
@@ -155,7 +154,6 @@ class NodePool(Generic[ClientT]):
         RuntimeError
             If the node pool has not been initialized.
         """
-
         if self._client is None:
             raise RuntimeError("NodePool has not been initialized.")
 
@@ -225,7 +223,6 @@ class NodePool(Generic[ClientT]):
         RuntimeError
             If the node pool has not been initialized.
         """
-
         if cls._client is None:
             raise RuntimeError("NodePool has not been initialized.")
 
@@ -277,7 +274,6 @@ class NodePool(Generic[ClientT]):
         ValueError
             If there are no nodes.
         """
-
         if node := choice(list(cls._nodes.values())):
             return node
 

--- a/mafic/pool.py
+++ b/mafic/pool.py
@@ -155,7 +155,8 @@ class NodePool(Generic[ClientT]):
             If the node pool has not been initialized.
         """
         if self._client is None:
-            raise RuntimeError("NodePool has not been initialized.")
+            msg = "NodePool has not been initialized."
+            raise RuntimeError(msg)
 
         node = Node(
             host=host,
@@ -224,7 +225,8 @@ class NodePool(Generic[ClientT]):
             If the node pool has not been initialized.
         """
         if cls._client is None:
-            raise RuntimeError("NodePool has not been initialized.")
+            msg = "NodePool has not been initialized."
+            raise RuntimeError(msg)
 
         actual_strategies: Sequence[StrategyCallable[ClientT] | Strategy]
 

--- a/mafic/pool.py
+++ b/mafic/pool.py
@@ -232,10 +232,7 @@ class NodePool(Generic[ClientT]):
 
         strategies = strategies or cls._default_strategies
 
-        if callable(strategies):
-            actual_strategies = [strategies]
-        else:
-            actual_strategies = strategies
+        actual_strategies = [strategies] if callable(strategies) else strategies
 
         nodes = cls.nodes
 

--- a/mafic/region.py
+++ b/mafic/region.py
@@ -1,3 +1,4 @@
+"""A module contains region enums for voice regions and groups."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -51,6 +52,7 @@ class VoiceRegion(Enum):
     AMSTERDAM = "amsterdam"
 
     def __repr__(self) -> str:
+        """Get the representation of this voice region."""
         return f"VoiceRegion.{self.name}"
 
 
@@ -89,6 +91,7 @@ class Region(Enum):
     OCEANIA = (VoiceRegion.SYDNEY,)
 
     def __repr__(self) -> str:
+        """Get the representation of this region."""
         return f"<Region.{self.name}>"
 
 
@@ -122,4 +125,5 @@ class Group(Enum):
     )
 
     def __repr__(self) -> str:
+        """Get the representation of this group."""
         return f"<Group.{self.name}>"

--- a/mafic/search_type.py
+++ b/mafic/search_type.py
@@ -1,3 +1,4 @@
+"""Represents a search type for Lavalink."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/mafic/stats.py
+++ b/mafic/stats.py
@@ -1,3 +1,4 @@
+"""A module containing classes to represent node statistics."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -84,7 +85,7 @@ class FrameStats:
 
 
 class NodeStats:
-    """Represents stats for a node.
+    r"""Represents stats for a node.
 
     Attributes
     ----------
@@ -98,7 +99,7 @@ class NodeStats:
         The memory stats of the node.
     cpu: :class:`CPUStats`
         The CPU stats of the node.
-    frame_stats: :data:`~typing.Optional`\\[:class:`FrameStats`]
+    frame_stats: :data:`~typing.Optional`\[:class:`FrameStats`]
         The frame stats of the node.
     """
 

--- a/mafic/strategy.py
+++ b/mafic/strategy.py
@@ -1,3 +1,4 @@
+"""The strategy system for selecting a :class:`Node` from a :class:`NodePool`."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -43,7 +44,7 @@ class Strategy(Enum):
 def shard_strategy(
     nodes: list[Node[ClientT]], guild_id: int, shard_count: int | None, _: str | None
 ) -> list[Node[ClientT]]:
-    """Selects a node based on the shard ID of the guild.
+    """Get a node based on the shard ID of the guild.
 
     Parameters
     ----------
@@ -56,7 +57,6 @@ def shard_strategy(
     _:
         Unused parameter.
     """
-
     if shard_count is None:
         shard_count = 1
 
@@ -73,7 +73,7 @@ _REGION_REGEX = re.compile(r"(?:vip-)?(?P<region>[a-z-]{1,15})\d{1,5}\.discord\.
 def location_strategy(
     nodes: list[Node[ClientT]], _: int, __: int | None, endpoint: str | None
 ) -> list[Node[ClientT]]:
-    """Selects a node based on the region the guild is in.
+    """Get a node based on the region the guild is in.
 
     Parameters
     ----------
@@ -86,7 +86,6 @@ def location_strategy(
     endpoint:
         The endpoint of the guild to select a node for.
     """
-
     if endpoint is None:
         return nodes
 
@@ -124,7 +123,7 @@ def location_strategy(
 def usage_strategy(
     nodes: list[Node[ClientT]], _: int, __: int | None, ___: str | None
 ) -> list[Node[ClientT]]:
-    """Selects a node based on the least used node.
+    """Get a node based on the least used node.
 
     This is calculated using :attr:`Node.weight`.
 
@@ -139,7 +138,6 @@ def usage_strategy(
     ___:
         Unused parameter.
     """
-
     # max() would be nice, however if all nodes have no stats, it returns the first.
 
     lowest = None
@@ -159,7 +157,7 @@ def usage_strategy(
 def random_strategy(
     nodes: list[Node[ClientT]], _: int, __: int | None, ___: str | None
 ) -> list[Node[ClientT]]:
-    """Selects a random node.
+    """Get a random node.
 
     Parameters
     ----------
@@ -172,7 +170,6 @@ def random_strategy(
     ___:
         Unused parameter.
     """
-
     return [choice(nodes)]
 
 
@@ -184,7 +181,7 @@ def call_strategy(
     shard_count: int | None,
     endpoint: str | None,
 ) -> list[Node[ClientT]]:
-    """Calls a strategy.
+    """Call a strategy's callback and get the result.
 
     Parameters
     ----------
@@ -199,7 +196,6 @@ def call_strategy(
     endpoint:
         The endpoint of the voice client to select a node for.
     """
-
     if strategy is Strategy.LOCATION:
         return location_strategy(nodes, guild_id, shard_count, endpoint)
     elif strategy is Strategy.RANDOM:

--- a/mafic/strategy.py
+++ b/mafic/strategy.py
@@ -206,4 +206,5 @@ def call_strategy(
     elif strategy is Strategy.USAGE:
         return usage_strategy(nodes, guild_id, shard_count, endpoint)
     else:
-        raise ValueError(f"Unknown strategy {strategy}")
+        msg = f"Unknown strategy {strategy}"
+        raise ValueError(msg)

--- a/mafic/strategy.py
+++ b/mafic/strategy.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from enum import Enum, auto
 from logging import getLogger
 from random import choice
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 from .node import Node
 from .type_variables import ClientT

--- a/mafic/track.py
+++ b/mafic/track.py
@@ -1,3 +1,4 @@
+"""The module containing :class:`Track`."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ __all__ = ("Track",)
 
 
 class Track:
-    """Represents a track.
+    r"""Represents a track.
 
     Parameters
     ----------
@@ -46,7 +47,7 @@ class Track:
         The author of the track.
     identifier: :class:`str`
         The identifier of the track. This is the ID of the track on the source.
-    uri: :data:`~typing.Optional`\\[:class:`str`]
+    uri: :data:`~typing.Optional`\[:class:`str`]
         The URI of the track.
     source: :class:`str`
         The source of the track.
@@ -119,7 +120,6 @@ class Track:
         :class:`Track`
             The track.
         """
-
         return cls(
             track_id=track,
             title=info["title"],
@@ -147,10 +147,10 @@ class Track:
         :class:`Track`
             The track.
         """
-
         return cls.from_data(track=data["encoded"], info=data["info"])
 
     def __repr__(self) -> str:
+        """Return the string representation of this track."""
         attrs = (
             ("id", self.id),
             ("title", self.title),

--- a/mafic/type_variables.py
+++ b/mafic/type_variables.py
@@ -1,3 +1,4 @@
+"""Type variables used in mafic."""
 # SPDX-License-Identifier: MIT
 # This was originally made to avoid the import cycle of
 # mafic.pool -> mafic.node -> mafic.pool
@@ -9,7 +10,7 @@ from .__libraries import Client
 
 __all__ = ("ClientT",)
 ClientT = TypeVar("ClientT", bound=Client)
-"""A type hint for a client that is (optionally a subclass of) your library's client.
+r"""A type hint for a client that is (optionally a subclass of) your library's client.
 
 - :class:`dpy:discord.Client` for discord.py.
 - :class:`nextcord.Client` for nextcord.
@@ -17,5 +18,5 @@ ClientT = TypeVar("ClientT", bound=Client)
 - :class:`pyc:discord.Client` for py-cord.
 
 This is used in :class:`.NodePool` to type hint the client used to create
-:class:`Node`\\s and :class:`Player`\\s. :attr:`Node.client` will be of this type.
+:class:`Node`\s and :class:`Player`\s. :attr:`Node.client` will be of this type.
 """

--- a/mafic/typings/__init__.py
+++ b/mafic/typings/__init__.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""
-mafic.typings
--------------
-A collection of Python types for the Lavalink API.
-"""
+"""A collection of Python types for the Lavalink API."""
 
 from .common import *
 from .http import *

--- a/mafic/typings/http.py
+++ b/mafic/typings/http.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT
+# ruff: noqa: UP013
+# `class` in `TypedDict` does not work as that is a reserved keyword
 
 from __future__ import annotations
 

--- a/mafic/typings/http.py
+++ b/mafic/typings/http.py
@@ -6,11 +6,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Optional, TypedDict, Union
 
-from .common import PlaylistInfo, TrackWithInfo
-
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
 
+    from .common import PlaylistInfo, TrackWithInfo
     from .misc import LavalinkException
 
 

--- a/mafic/typings/misc.py
+++ b/mafic/typings/misc.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Coroutine, Literal, TypedDict, TypeVar
+from collections.abc import Coroutine
+from typing import Any, Literal, TypedDict, TypeVar
 
 __all__ = (
     "Coro",

--- a/mafic/typings/outgoing.py
+++ b/mafic/typings/outgoing.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import List, TypedDict, Union
+from typing import TYPE_CHECKING, List, TypedDict, Union
 
-from .common import Filters, VoiceStateRequest
+if TYPE_CHECKING:
+    from .common import Filters, VoiceStateRequest
 
 __all__ = (
     "DecodeTrackParams",

--- a/mafic/utils/__init__.py
+++ b/mafic/utils/__init__.py
@@ -1,3 +1,4 @@
+"""Utilities for both Mafic users and internal uses."""
 # SPDX-License-Identifier: MIT
 
 from .classproperty import *

--- a/mafic/utils/classproperty.py
+++ b/mafic/utils/classproperty.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Generic, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 

--- a/mafic/utils/classproperty.py
+++ b/mafic/utils/classproperty.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 

--- a/mafic/utils/classproperty.py
+++ b/mafic/utils/classproperty.py
@@ -1,3 +1,4 @@
+"""Contains a decorator to merge properties and classmethods."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -24,14 +25,13 @@ class _ClassPropertyDescriptor(Generic[T]):
 def classproperty(
     func: Callable[..., T] | classmethod[T] | staticmethod[T]
 ) -> _ClassPropertyDescriptor[T]:
-    """A decorator that mimics the behavior of a property, but for classmethods.
+    """Contains a decorator to mimic the behavior of a property, but for classmethods.
 
     Parameters
     ----------
     func:
         The function to decorate.
     """
-
     if not isinstance(func, (classmethod, staticmethod)):
         func = classmethod(func)
 

--- a/mafic/utils/classproperty.py
+++ b/mafic/utils/classproperty.py
@@ -14,7 +14,9 @@ __all__ = ("classproperty",)
 class _ClassPropertyDescriptor(Generic[T]):
     """A descriptor that mimics the behavior of a property, but for classmethods."""
 
-    def __init__(self, fget: classmethod[T] | staticmethod[T], fset: None = None):
+    def __init__(
+        self, fget: classmethod[T] | staticmethod[T], fset: None = None
+    ) -> None:
         self.fget = fget
 
     def __get__(self, instance: object, owner: type | None = None) -> T:

--- a/mafic/utils/classproperty.py
+++ b/mafic/utils/classproperty.py
@@ -16,9 +16,7 @@ __all__ = ("classproperty",)
 class _ClassPropertyDescriptor(Generic[T]):
     """A descriptor that mimics the behavior of a property, but for classmethods."""
 
-    def __init__(
-        self, fget: classmethod[T] | staticmethod[T], fset: None = None
-    ) -> None:
+    def __init__(self, fget: classmethod[T] | staticmethod[T]) -> None:
         self.fget = fget
 
     def __get__(self, instance: object, owner: type | None = None) -> T:

--- a/mafic/utils/decode.py
+++ b/mafic/utils/decode.py
@@ -89,10 +89,11 @@ class _TrackDataIterator(Iterator[int]):
             return None
 
         if (byte := next(self)) != 0:
-            raise ValueError(
+            msg = (
                 "Attempted to traverse a track id "
                 f"and came across an unexpected character: {byte}."
             )
+            raise ValueError(msg)
 
         return self.read_str()
 

--- a/mafic/utils/decode.py
+++ b/mafic/utils/decode.py
@@ -25,7 +25,7 @@ class _TrackDataIterator(Iterator[int]):
     _TRACK_INFO_VERSIONED = 1
     _FLAG_MASK = 0xC0000000
 
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes) -> None:
         self.__iterable = iter(data)
 
         # https://github.com/sedmelluq/lavaplayer/blob/97a8efecfe3cb79da4d7d0422de0179e18c30947/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/MessageInput.java#L37

--- a/mafic/utils/decode.py
+++ b/mafic/utils/decode.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from base64 import b64decode
-from typing import Iterator
+from collections.abc import Iterator
 
 from ..track import Track
 

--- a/mafic/utils/decode.py
+++ b/mafic/utils/decode.py
@@ -118,7 +118,7 @@ def decode_track(track_id: str) -> Track:
         The decoded track.
     """
     raw = b64decode(track_id)
-    print(raw)
+    # print(raw)
     iterator = _TrackDataIterator(raw)
 
     # https://github.com/sedmelluq/lavaplayer/blob/97a8efecfe3cb79da4d7d0422de0179e18c30947/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java#L268

--- a/mafic/utils/decode.py
+++ b/mafic/utils/decode.py
@@ -1,3 +1,4 @@
+"""A module to decode a track id into a Track object."""
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -115,7 +116,6 @@ def decode_track(track_id: str) -> Track:
     Track:
         The decoded track.
     """
-
     raw = b64decode(track_id)
     print(raw)
     iterator = _TrackDataIterator(raw)

--- a/mafic/warnings.py
+++ b/mafic/warnings.py
@@ -1,3 +1,4 @@
+"""Contains the warnings shown from Mafic."""
 # SPDX-License-Identifier: MIT
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,8 @@ select = [
     "Q",
     "RSE",
     "RET",
-    "SLF",
     "SIM",
+    "TCH",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,18 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "I", "W"]
-ignore = ["F403", "F405"]
+select = ["E", "F", "W", "I", "D"]
+# F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
+# D107, class docstr is in the class level, may change in future.
+# D203 and D211, D212 and D213 intentionally clash
+ignore = ["F403", "F405", "D107", "D203", "D213"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
+"mafic/typings/*" = ["D"]
+"test_bot/*" = ["D"]
+"docs/*" = ["D"]
+"examples/*" = ["D"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ select = [
     "RSE",
     "RET",
     "SLF",
+    "SIM",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ select = [
     "PLE",
     "PLR",
     "PLW",
+    "TRY",
+    "RUF",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4", "DTZ"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4", "DTZ", "T10", "EM"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,11 @@ pyright = "1.1.289"
 black = "^22.8.0"
 isort = "^5.10.1"
 taskipy = "^1.10.3"
-flake8 = "^5.0.4"
 pre-commit = "^2.20.0"
 python-dotenv = "^0.21.0"
 slotscheck = "^0.15.0"
-Flake8-pyproject = "^1.1.0.post0"
 typing-extensions = "^4.3.0"
+ruff = "^0.0.251"
 
 [tool.poetry.group.lint.dependencies]
 nextcord = "^2.0.0"
@@ -75,7 +74,7 @@ pre-commit = "pre-commit install --install-hooks"
 lint = "pre-commit run --all-files"
 black = "task lint black"
 isort = "task lint isort"
-flake8 = "task lint flake8"
+ruff = "task lint ruff"
 slotscheck = "task lint slotscheck"
 pyright = "dotenv -f task.env run -- pyright"
 docs = "cd docs && sphinx-autobuild . _build/html --ignore _build --watch ../mafic --port 8069"
@@ -100,6 +99,13 @@ require-subclass = false
 typeCheckingMode = "strict"
 pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
+
+[tool.ruff]
+select = ["E", "F"]
+ignore = ["F403", "F405"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,14 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D"]
+select = ["E", "F", "W", "I", "D", "UP"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash
 ignore = ["F403", "F405", "D107", "D203", "D213"]
+
+[tool.ruff.pyupgrade]
+keep-runtime-typing = true
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
     "RET",
     "SIM",
     "TCH",
+    "ARG",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash
@@ -108,9 +108,9 @@ keep-runtime-typing = true
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "mafic/typings/*" = ["D"]
-"test_bot/*" = ["D", "ANN"]
+"test_bot/*" = ["D", "ANN", "S101", "S106"]
 "docs/*" = ["D"]
-"examples/*" = ["D", "ANN"]
+"examples/*" = ["D", "ANN", "S101", "S106"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ select = [
     "SIM",
     "TCH",
     "ARG",
+    "PGH",
+    "PLC",
+    "PLE",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ speedups = ["orjson"]
 [tool.poetry.group.dev.dependencies]
 pyright = "1.1.289"
 black = "^22.8.0"
-isort = "^5.10.1"
 taskipy = "^1.10.3"
 pre-commit = "^2.20.0"
 python-dotenv = "^0.21.0"
@@ -73,7 +72,6 @@ sphinx-autodoc-typehints = "^1.21.8"
 pre-commit = "pre-commit install --install-hooks"
 lint = "pre-commit run --all-files"
 black = "task lint black"
-isort = "task lint isort"
 ruff = "task lint ruff"
 slotscheck = "task lint slotscheck"
 pyright = "dotenv -f task.env run -- pyright"
@@ -83,12 +81,8 @@ docs = "cd docs && sphinx-autobuild . _build/html --ignore _build --watch ../maf
 line-length = 88
 target-version = ["py38", "py39", "py310"]
 
-[tool.isort]
-profile = "black"
-py_version = 38
-line_length = 88
-combine_as_imports = true
-filter_files = true
+[tool.ruff.isort]
+combine-as-imports = true
 
 [tool.slotscheck]
 strict-imports = true
@@ -101,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F"]
+select = ["E", "F", "I", "W"]
 ignore = ["F403", "F405"]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,12 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash
-ignore = ["F403", "F405", "D107", "D203", "D213"]
+# ANN101, ANN102 ask for `self` and `cls` annotations, what?
+ignore = ["F403", "F405", "D107", "D203", "D213", "ANN101", "ANN102"]
 
 [tool.ruff.pyupgrade]
 keep-runtime-typing = true
@@ -107,9 +108,9 @@ keep-runtime-typing = true
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "mafic/typings/*" = ["D"]
-"test_bot/*" = ["D"]
+"test_bot/*" = ["D", "ANN"]
 "docs/*" = ["D"]
-"examples/*" = ["D"]
+"examples/*" = ["D", "ANN"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "lavalink",
     "lavalink.py",
     "pycord",
-    "py-cord"
+    "py-cord",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -25,17 +25,15 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Typing :: Typed"
+    "Typing :: Typed",
 ]
 
-packages = [
-    { include = "mafic" },
-]
+packages = [{ include = "mafic" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 aiohttp = "^3.6.0"
-orjson = {version = "^3.8.0", optional = true}
+orjson = { version = "^3.8.0", optional = true }
 yarl = "^1.0.0"
 
 [tool.poetry.extras]
@@ -95,12 +93,51 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4", "DTZ", "T10", "EM"]
+select = [
+    "E",
+    "F",
+    "W",
+    "I",
+    "D",
+    "UP",
+    "YTT",
+    "ANN",
+    "S",
+    "BLE",
+    "FBT",
+    "B",
+    "C4",
+    "DTZ",
+    "T10",
+    "EM",
+    "ISC",
+    "G",
+    "PIE",
+    "T20",
+    "Q",
+    "RSE",
+    "RET",
+    "SLF",
+]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash
 # ANN101, ANN102 ask for `self` and `cls` annotations, what?
-ignore = ["F403", "F405", "D107", "D203", "D213", "ANN101", "ANN102"]
+# RET505-RET508 does not allow for any branches where it is an elif and else after a return
+ignore = [
+    "F403",
+    "F405",
+    "D107",
+    "D203",
+    "D213",
+    "ANN101",
+    "ANN102",
+    "RET505",
+    "RET506",
+    "RET507",
+    "RET508",
+]
+unfixable = ["RET502", "RET503"]
 
 [tool.ruff.pyupgrade]
 keep-runtime-typing = true
@@ -108,9 +145,9 @@ keep-runtime-typing = true
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "mafic/typings/*" = ["D"]
-"test_bot/*" = ["D", "ANN", "S101", "S106"]
+"test_bot/*" = ["D", "ANN", "S101", "S106", "RET"]
 "docs/*" = ["D"]
-"examples/*" = ["D", "ANN", "S101", "S106"]
+"examples/*" = ["D", "ANN", "S101", "S106", "RET"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pythonVersion = "3.8"
 ignore = ["test_bot", "examples/**"]
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4"]
+select = ["E", "F", "W", "I", "D", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "C4", "DTZ"]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,12 +123,15 @@ select = [
     "PGH",
     "PLC",
     "PLE",
+    "PLR",
+    "PLW",
 ]
 # F403, F405 do not need to hate wildcard imports. Pyright can find undefined errors.
 # D107, class docstr is in the class level, may change in future.
 # D203 and D211, D212 and D213 intentionally clash
 # ANN101, ANN102 ask for `self` and `cls` annotations, what?
 # RET505-RET508 does not allow for any branches where it is an elif and else after a return
+# PLR2004 too much to deal with right now
 ignore = [
     "F403",
     "F405",
@@ -141,6 +144,7 @@ ignore = [
     "RET506",
     "RET507",
     "RET508",
+    "PLR2004",
 ]
 unfixable = ["RET502", "RET503"]
 

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 import orjson
 from botbase import BotBase
 from nextcord import Intents, Interaction
-from nextcord.abc import Connectable
 
 from mafic import (
     EQBand,
@@ -30,6 +29,7 @@ from mafic import (
 if TYPE_CHECKING:
     from typing import TypedDict
 
+    from nextcord.abc import Connectable
     from typing_extensions import NotRequired
 
     class LavalinkInfo(TypedDict):

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -82,7 +82,7 @@ class TestBot(BotBase):
                 regions = []
                 for region_str in node["regions"]:
                     for cls in REGION_CLS:
-                        if region_str in cls.__members__.keys():
+                        if region_str in cls.__members__:
                             region = cls[region_str]
                             break
                     else:

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -153,6 +153,7 @@ async def play(inter: Interaction, query: str):
     await player.play(track)
 
     await inter.send(f"Playing {track}")
+    return None
 
 
 @bot.slash_command()
@@ -165,6 +166,7 @@ async def stop(inter: Interaction):
 
     await player.stop()
     await inter.send("Stopped playing.")
+    return None
 
 
 @bot.listen()
@@ -210,6 +212,7 @@ async def stats(inter: Interaction):
             playing_player_count=stats.playing_player_count,
         )
     )
+    return None
 
 
 # Test bot, do not have an open close command.
@@ -232,6 +235,7 @@ async def boost(inter: Interaction):
     await player.add_filter(bassboost_filter, label="boost")
 
     await inter.send("Boost enabled.")
+    return None
 
 
 @bot.slash_command()
@@ -244,6 +248,7 @@ async def unboost(inter: Interaction):
     await player.remove_filter("boost")
 
     await inter.send("Boost disabled.")
+    return None
 
 
 bot.run(getenv("TOKEN"))

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -47,7 +47,7 @@ getLogger("mafic").setLevel(DEBUG)
 
 
 class TestBot(BotBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             shard_count=2 if getenv("TEST_BALANCING") else None,
             shard_ids=[0, 1] if getenv("TEST_BALANCING") else None,

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -60,14 +60,14 @@ class TestBot(BotBase):
     # Gateway-proxy is used to keep gateway connections alive.
     # This is added in testing to ensure resuming a connection works, even over restart.
     async def launch_shard(
-        self, gateway: str, shard_id: int, *, initial: bool = False
+        self, _gateway: str, shard_id: int, *, initial: bool = False
     ) -> None:
         return await super().launch_shard(
             environ["GW_PROXY"], shard_id, initial=initial
         )
 
     async def before_identify_hook(
-        self, shard_id: int | None, *, initial: bool = False
+        self, _shard_id: int | None, *, initial: bool = False  # noqa: ARG002
     ) -> None:
         # gateway-proxy
         return

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -117,7 +117,6 @@ class MyPlayer(Player[TestBot]):
 @bot.slash_command()
 async def join(inter: Interaction):
     """Join your voice channel."""
-
     if not inter.user.voice:
         return await inter.response.send_message("You are not in a voice channel.")
 
@@ -133,7 +132,6 @@ async def play(inter: Interaction, query: str):
     query:
         The song to search or play.
     """
-
     if not inter.guild.voice_client:
         await join(inter)
 
@@ -159,7 +157,6 @@ async def play(inter: Interaction, query: str):
 @bot.slash_command()
 async def stop(inter: Interaction):
     """Stop playing."""
-
     if not inter.guild.voice_client:
         return await inter.send("I am not in a voice channel.")
 

--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -86,7 +86,8 @@ class TestBot(BotBase):
                             region = cls[region_str]
                             break
                     else:
-                        raise ValueError(f"Invalid region: {region_str}")
+                        msg = f"Invalid region: {region_str}"
+                        raise ValueError(msg)
 
                     regions.append(region)
 


### PR DESCRIPTION
## Summary

Ruff has plenty of plugins to ensure consistent and safe style. It eliminates the need to run flake8 and isort, which speeds up linting.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
