### PR TITLE
feat(filter): allow more types for Equalizer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Set up pyright
-        run: echo "PYRIGHT_VERSION=$(poetry run python -c 'import pyright; print(pyright.__pyright_version__)')" >> $GITHUB_ENV
+        run: echo "PYRIGHT_VERSION=$(python -c 'import pyright; print(pyright.__pyright_version__)')" >> $GITHUB_ENV
 
       - name: Run pyright (Linux)
         uses: jakebailey/pyright-action@v1.4.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         uses: snok/install-poetry@v1
 
       - name: Export dependencies
-        run: poetry export --no-interaction -f requirements.txt --output requirements.txt --with lint,docs
+        run: poetry export --no-interaction -f requirements.txt --output requirements.txt --with lint,docs,dev
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ unfixable = ["RET502", "RET503"]
 [tool.ruff.pyupgrade]
 keep-runtime-typing = true
 
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "mafic/typings/*" = ["D"]


### PR DESCRIPTION
## Summary

This allows more types to be passed to `Equalizer` and `Filter`.
This has the side effect of adding `__slots__` to `Equalizer` and `Filter`, since
dataclasses don't support `__slots__` in <3.10.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
