### PR TITLE
feat(player): add has_filter method

### DIFF
--- a/mafic/player.py
+++ b/mafic/player.py
@@ -683,6 +683,23 @@ class Player(VoiceProtocol, Generic[ClientT]):
 
         await self._update_filters(fast_apply=fast_apply)
 
+    async def has_filter(self, label: str) -> bool:
+        """Check if the player has a filter with the given label.
+
+        .. versionadded:: 2.1
+
+        Parameters
+        ----------
+        label:
+            The label to check for.
+
+        Returns
+        -------
+        :class:`bool`
+            Whether the player has a filter with the given label.
+        """
+        return label in self._filters
+
     async def remove_filter(self, label: str, *, fast_apply: bool = False) -> None:
         """Remove a filter from the player.
 


### PR DESCRIPTION
## Summary

Add `Player.has_filter`, a way to check if a filter is enabled in that `Player`.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
