### PR TITLE
fix(node): urlencode query

### DIFF
--- a/mafic/node.py
+++ b/mafic/node.py
@@ -11,6 +11,7 @@ from asyncio import Event, TimeoutError, create_task, gather, sleep, wait_for
 from logging import getLogger
 from traceback import print_exc
 from typing import TYPE_CHECKING, Generic, cast
+from urllib.parse import quote
 
 import aiohttp
 import yarl
@@ -964,7 +965,7 @@ class Node(Generic[ClientT]):
             query = f"{search_type}:{query}"
 
         data: TrackLoadingResult = await self.__request(
-            "GET", "loadtracks", params={"identifier": query}
+            "GET", "loadtracks", params={"identifier": quote(query)}
         )
 
         if data["loadType"] == "NO_MATCHES":


### PR DESCRIPTION
## Summary

URL encode `identifier` when querying a track. This fixes an issue where
track names with spaces would not be found.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
