### PR TITLE
fix(stats); check if frame stats is None

### DIFF
--- a/mafic/stats.py
+++ b/mafic/stats.py
@@ -119,5 +119,7 @@ class NodeStats:
         self.memory: MemoryStats = MemoryStats(data["memory"])
         self.cpu: CPUStats = CPUStats(data["cpu"])
         self.frame_stats: FrameStats | None = (
-            FrameStats(data["frameStats"]) if "frameStats" in data else None
+            FrameStats(data["frameStats"])
+            if "frameStats" in data and data["frameStats"] is not None
+            else None
         )

--- a/mafic/typings/common.py
+++ b/mafic/typings/common.py
@@ -171,4 +171,5 @@ class Stats(TypedDict):
     uptime: int
     memory: Memory
     cpu: CPU
-    frameStats: NotRequired[FrameStats]
+    # V3 is NotRequired, V4 is None
+    frameStats: NotRequired[FrameStats | None]


### PR DESCRIPTION
## Summary

Lavalink V4 uses `None` instead of ommitability for `frameStats`.

```
03.05.2023 23:58:16 | DEBUG | Creating task to handle websocket message.
03.05.2023 23:58:16 | DEBUG | Event data: {'frameStats': None, 'players': 1, 'playingPlayers': 1, 'uptime': 423901, 'memory': {'free': 928557288, 'used': 145184536, 'allocated': 1073741824, 'reservable': 1073741824}, 'cpu': {'cores': 4, 'systemLoad': 0.0564602352167119, 'lavalinkLoad': 0.026292104868414472}, 'op': 'stats'}
03.05.2023 23:58:16 | DEBUG | Received event with op stats
03.05.2023 23:58:18 | DEBUG | Received message from websocket.
03.05.2023 23:58:18 | DEBUG | Creating task to handle websocket message.
03.05.2023 23:58:18 | ERROR | Task exception was never retrieved
future: <Task finished name='Task-68' coro=<Node._handle_msg() done, defined at C:\Users\Cattosatus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\node.py:713> exception=TypeError("'NoneType' object is not subscriptable")>
Traceback (most recent call last):
  File "C:\Users\Cattosatus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\node.py", line 739, in _handle_msg
    self._stats = NodeStats(data)
  File "C:\Users\Cattosatus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\stats.py", line 122, in __init__
    FrameStats(data["frameStats"]) if "frameStats" in data else None
  File "C:\Users\Cattosatus\AppData\Local\Programs\Python\Python39\lib\site-packages\mafic\stats.py", line 82, in __init__
    self.sent: int = payload["sent"]
TypeError: 'NoneType' object is not subscriptable
03.05.2023 23:58:18 | DEBUG | Event data: {'state': {'time': 1683147498126, 'position': 55121, 'connected': True, 'ping': 45}, 'guildId': '1071227694685110343', 'op': 'playerUpdate'}
03.05.2023 23:58:18 | DEBUG | Received event with op playerUpdate
```

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
