### PR TITLE
fix(player): Player.connected being False sometimes

### DIFF
--- a/test_bot/bot/__main__.py
+++ b/test_bot/bot/__main__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import traceback
 from asyncio import gather
 from logging import DEBUG, getLogger
@@ -136,8 +137,15 @@ async def join(inter: Interaction):
     if not inter.user.voice:
         return await inter.response.send_message("You are not in a voice channel.")
 
+    await inter.response.defer()
+
     channel = inter.user.voice.channel
-    await channel.connect(cls=MyPlayer)
+
+    try:
+        await channel.connect(cls=MyPlayer, timeout=5)
+    except asyncio.TimeoutError:
+        return await inter.send("Timed out connecting to voice channel.")
+
     await inter.send(f"Joined {channel.mention}.")
 
 


### PR DESCRIPTION
## Summary

`Player.connected` may be `False` but still be in the client's dictionary if it failed to connect.
One example is trying to connect a player where the bot cannot join due to user limits in the channel.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
