### PR TITLE
feat(player): support str for playing identifiers

### DIFF
--- a/mafic/node.py
+++ b/mafic/node.py
@@ -880,14 +880,14 @@ class Node(Generic[ClientT]):
         self,
         *,
         guild_id: int,
-        track: Track | None = MISSING,
+        track: Track | str | None = MISSING,
         position: int | None = None,
         end_time: int | None = None,
         volume: int | None = None,
         no_replace: bool | None = None,
         pause: bool | None = None,
         filter: Filter | None = None,
-    ) -> Coro[None]:
+    ) -> Coro[PlayerPayload]:
         """Update a player.
 
         Parameters
@@ -896,7 +896,11 @@ class Node(Generic[ClientT]):
             The guild ID to update the player for.
         track:
             The track to update the player with.
+            This can be either a :class:`Track` or an identifier.
             Setting this to ``None`` will clear the track.
+
+            .. versionchanged:: 2.4
+                The track can now be a :class:`str` to play an identifier.
         position:
             The position to update the player with.
         end_time:
@@ -913,7 +917,10 @@ class Node(Generic[ClientT]):
         data: UpdatePlayerPayload = {}
 
         if track is not MISSING:
-            data["encodedTrack"] = track.id if track is not None else None
+            if isinstance(track, Track) or track is None:
+                data["encodedTrack"] = track.id if track is not None else None
+            else:
+                data["identifier"] = track
 
         if position is not None:
             data["position"] = position

--- a/mafic/player.py
+++ b/mafic/player.py
@@ -510,7 +510,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
     async def update(
         self,
         *,
-        track: Track | None = MISSING,
+        track: Track | str | None = MISSING,
         position: int | None = None,
         end_time: int | None = None,
         volume: int | None = None,
@@ -523,7 +523,10 @@ class Player(VoiceProtocol, Generic[ClientT]):
         Parameters
         ----------
         track:
-            The track to play.
+            The track to play. This can be a :class:`Track` or an identifier.
+
+            .. versionchanged:: 2.4
+                The track can now be a :class:`str` to play an identifier.
         position:
             The position to start the track at.
         end_time:
@@ -545,13 +548,7 @@ class Player(VoiceProtocol, Generic[ClientT]):
         if self._node is None or not self._connected:
             raise PlayerNotConnected
 
-        if track is not MISSING:
-            self._current = track
-
-        if position is not None:
-            self._position = position
-
-        await self._node.update(
+        data = await self._node.update(
             guild_id=self._guild_id,
             track=track,
             position=position,
@@ -562,12 +559,18 @@ class Player(VoiceProtocol, Generic[ClientT]):
             no_replace=not replace,
         )
 
-        if pause is not None:
-            self._paused = pause
+        if data["track"]:
+            self._current = Track.from_data_with_info(data["track"])
+
+        if data["volume"]:
+            self._volume = data["volume"]
+
+        if data["paused"]:
+            self._paused = data["paused"]
 
     async def play(
         self,
-        track: Track,
+        track: Track | str,
         /,
         *,
         start_time: int | None = None,
@@ -581,7 +584,10 @@ class Player(VoiceProtocol, Generic[ClientT]):
         Parameters
         ----------
         track:
-            The track to play.
+            The track to play. This can be a :class:`Track` or an identifier.
+
+            .. versionchanged:: 2.4
+                The track can now be a :class:`str` to play an identifier.
         start_time:
             The position to start the track at.
         end_time:


### PR DESCRIPTION
## Summary

Pass `str` to `Player.play`/`Player.update` to play using an `identifier`.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
