### PR TITLE
fix(player): pre-emptively update .current if v3

### DIFF
--- a/mafic/player.py
+++ b/mafic/player.py
@@ -570,6 +570,18 @@ class Player(VoiceProtocol, Generic[ClientT]):
         if self._node is None or not self._connected:
             raise PlayerNotConnected
 
+        # v4+ receives the full payload in events, so there is no need to
+        # pre-emptyively update the player.
+        if track is not None and self.node.version == 3:
+            if isinstance(track, str):
+                message = (
+                    "Lavalink version 3 does not support identifiers "
+                    "due to unexpected behaviour with events."
+                )
+                raise TypeError(message)
+
+            self._current = track
+
         data = await self._node.update(
             guild_id=self._guild_id,
             track=track,


### PR DESCRIPTION
## Summary

This fixes a regression in 2.4.0 where `.current` is not set before sending an API request.
This meant that on lavalink v3, a full track object could not be found sometiems when the event was recieved.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
