### PR TITLE
fix(node): fix decode_track parsing

### DIFF
--- a/mafic/node.py
+++ b/mafic/node.py
@@ -1123,11 +1123,11 @@ class Node(Generic[ClientT]):
         --------
         :meth:`decode_tracks`
         """
-        track: TrackWithInfo = await self.__request(
+        track_object: TrackWithInfo = await self.__request(
             "GET", "decodetrack", params={"encodedTrack": track}
         )
 
-        return Track.from_data_with_info(track)
+        return Track.from_data_with_info(track_object)
 
     async def decode_tracks(self, tracks: list[str]) -> list[Track]:
         r"""Decode a list of tracks from the encoded base64 data.

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
         Player as PlayerPayload,
         PluginData,
         RoutePlannerStatus as RoutePlannerStatusPayload,
-        TrackInfo,
         TrackLoadingResult,
         UpdatePlayerParams,
         UpdatePlayerPayload,
@@ -94,9 +93,9 @@ def _wrap_regions(
     for item in regions:
         if isinstance(item, Group):
             for region in item.value:
-                actual_regions.append(region.value)
+                actual_regions.extend(region.value)
         elif isinstance(item, Region):
-            actual_regions.append(item.value)
+            actual_regions.extend(item.value)
         elif isinstance(
             item, VoiceRegion
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
@@ -1124,11 +1123,11 @@ class Node(Generic[ClientT]):
         --------
         :meth:`decode_tracks`
         """
-        info: TrackInfo = await self.__request(
+        track: TrackWithInfo = await self.__request(
             "GET", "decodetrack", params={"encodedTrack": track}
         )
 
-        return Track.from_data(track=track, info=info)
+        return Track.from_data_with_info(track)
 
     async def decode_tracks(self, tracks: list[str]) -> list[Track]:
         r"""Decode a list of tracks from the encoded base64 data.


### PR DESCRIPTION
## Summary

v4 decode_tracks uses `info` embedded instead of a track info by itself.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
