### PR TITLE
fead(node): add on_node_stats

### DIFF
--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -63,3 +63,12 @@ Callbacks
 
    :param event: The event that was dispatched.
    :type event: :class:`TrackStuckEvent`
+
+.. function:: on_node_stats()
+
+   Called when Lavalink sends node statistics.
+
+   .. versionadded:: 2.5
+
+   :param node: The node that sent the statistics.
+   :type node: :class:`Node`

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -736,6 +736,7 @@ class Node(Generic[ClientT]):
             player.update_state(data["state"])
         elif data["op"] == "stats":
             self._stats = NodeStats(data)
+            self.client.dispatch("node_stats", self)
         elif data["op"] == "event":
             await self._handle_event(data)
         elif data["op"] == "ready":


### PR DESCRIPTION
## Summary

Add `on_node_stats` that is dispatched every time a node's stats are received. This is for the purpose of updating and dispatching updates to metrics servers or other internal state.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
