### PR TITLE
feat: transfer players to new nodes

### DIFF
--- a/test_bot/.dockerignore
+++ b/test_bot/.dockerignore
@@ -3,3 +3,4 @@
 !pyproject.toml
 !poetry.lock
 !lavalink/
+!gateway-proxy/

--- a/test_bot/docker-compose.multi-node.yml
+++ b/test_bot/docker-compose.multi-node.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   bot:
+    restart: on-failure:5
     depends_on:
       - lavalink
     build: .
@@ -10,21 +11,33 @@ services:
       - ../mafic:/bot/mafic
     environment:
       TOKEN: $TOKEN
-      GW_PROXY: ws://127.0.0.1:7878
+      GW_PROXY: ws://localhost:7878
       LAVALINK_FILE: lavalink/multi-nodes.json
     network_mode: host
   lavalink:
-    build: lavalink
+    image: ghcr.io/freyacodes/lavalink:v4
     volumes:
       - ./logs/lava:/opt/Lavalink/logs
     deploy:
       replicas: 8
     ports:
       - "6962-6969:6969"
+    environment:
+      JDK_JAVA_OPTIONS: -Xmx2G
+      SERVER_PORT: 6969
+      SERVER_ADDRESS: 0.0.0.0
+      LAVALINK_SERVER_PASSWORD: haha
+      LOGGING_FILE_PATH: ./logs/
+      LOGGING_LEVEL_ROOT: INFO
+      LOGGING_LEVEL_LAVALINK: INFO
+      LOGGING_REQUEST_ENABLED: true
+      LOGGING_LOGBACK_ROLLINGPOLICY_MAXFILESIZE: 100MB
+      LOGGING_LOGBACK_ROLLINGPOLICY_MAXHISTORY: 30
   gateway-proxy:
     image: gelbpunkt/gateway-proxy:x86-64
     volumes:
       - ./gateway-proxy/noshard.config.json:/config.json
     environment:
       TOKEN: $TOKEN
-    network_mode: host
+    ports:
+      - "7878:7878"


### PR DESCRIPTION
## Summary

This is impressive that it even works.

`NodePool.remove_node` has been added, which has a `transfer_players` keyword argument, which:

- `False`: destroys all players
- `True`: `Player.transfer_to` with the best node per player

`Player.transfer_to` tries its best to:

- Fetch existing player state from old node
- Remove player from internal old node state
- Add player to internal new node state
- Tell the new node about our voice config (endpoint, session id, token)
- Update the new player with track, position, volume, pause, filter

`Node.close` was also added to disconnect and cleanup an old node, called in `NodePool.remove_node`

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
