### PR TITLE
feat(node): support unavailable node handling

### DIFF
--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -72,3 +72,17 @@ Callbacks
 
    :param node: The node that sent the statistics.
    :type node: :class:`Node`
+
+.. function:: on_node_ready()
+
+    Called when Lavalink node is ready.
+
+    :param node: The node that was ready.
+    :type node: :class:`Node`
+
+.. function:: on_node_unavailable()
+
+    Called when Lavalink node becomes unavailable.
+
+    :param node: The node that became unavailable.
+    :type node: :class:`Node`

--- a/mafic/node.py
+++ b/mafic/node.py
@@ -759,7 +759,9 @@ class Node(Generic[ClientT]):
 
             if _type is aiohttp.WSMsgType.CLOSED:
                 self._available = False
+                self._client.dispatch("node_unavailable", self)
                 close_code = self._ws.close_code
+                self._ready.clear()
                 self._ws = None
 
                 wait_time = backoff.delay()

--- a/mafic/pool.py
+++ b/mafic/pool.py
@@ -91,8 +91,8 @@ class NodePool(Generic[ClientT]):
 
     @classproperty
     def nodes(cls) -> list[Node[ClientT]]:
-        """Get the list of all nodes."""
-        return list(cls._nodes.values())
+        """Get the list of all available nodes."""
+        return list(filter(lambda n: n.available, cls._nodes.values()))
 
     async def create_node(
         self,
@@ -364,7 +364,10 @@ class NodePool(Generic[ClientT]):
         ValueError
             If there are no nodes.
         """
-        if node := choice(list(cls._nodes.values())):
+        # It is a classproperty.
+        nodes = cast(list[Node[ClientT]], cls.nodes)  # pyright: ignore  # noqa: PGH003
+
+        if node := choice(nodes):
             return node
 
         raise NoNodesAvailable


### PR DESCRIPTION
## Summary

Add `on_node_unavailable` that is dispatched when `Node.available` become `False`
Modify NodePool.nodes to return only available nodes, preventing players from attempting to connect to unavailable nodes.
Fix doesn't wait for ready `Node.connect` when reconnecting to the node.

## Checklist

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
