### PR TITLE
chore(LICENSE): add `present` suffix to year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Oliver Wilkes
+Copyright (c) 2022-present Oliver Wilkes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
HAPPY NEW YEAR!!!! (:trollface:)

This adds the `-present` suffix to the year so that the license still applies to the current year.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have run `task lint` to format code and my changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
