### PR TITLE
refactor(__libraries): bump library version requirement to 2 or 3

### DIFF
--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -135,6 +135,6 @@ except ImportError:
     from json import dumps, loads
 
 
-if version_info.major != 2:
-    msg = f"Mafic requires version 2 of {library}."
+if version_info.major < 2 or version_info.major > 3:
+    msg = f"Mafic requires version 2 or 3 of {library}."
     raise RuntimeError(msg)


### PR DESCRIPTION
## Summary

Allows for users to install libraries that exeed version 2 and not throw a RuntimeError as nextcord released v3 a few weeks ago

## Checklist

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
