### PR TITLE
fix(docs): add sphinx config to `sphinx.configuration` key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,3 +20,4 @@ build:
       # Poetry setup still seems to fail on readthedocs.
 sphinx:
   fail_on_warning: false
+  configuration: docs/conf.py


### PR DESCRIPTION
## Summary

Adds `configuration` linking to the docs/conf.py file in the readthedocs config file.

https://readthedocs.org/projects/mafic/builds/26835213/

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
- [ ] I have run `task lint` to format code and my changes.
- [ ] I have run `task pyright` and fixed the relevant issues.
