### PR TITLE
docs(rtd): fix poetry install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.8
 
       - name: Load cached Poetry installation
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,15 +10,11 @@ build:
     python: "3.11"
   jobs:
     # See https://github.com/readthedocs/readthedocs.org/issues/4912
-    pre_create_environment:
-      - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
-      - poetry config virtualenvs.create false
     post_install:
       # - poetry export --no-interaction -f requirements.txt --output requirements.txt --with lint,docs
       # - pip install -r requirements.txt
       # Poetry setup still seems to fail on readthedocs.
+      - pip install poetry
       - poetry install --with lint,docs
 sphinx:
   fail_on_warning: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   jobs:
@@ -15,7 +15,7 @@ build:
       # - pip install -r requirements.txt
       # Poetry setup still seems to fail on readthedocs.
       - pip install poetry
-      - poetry install --with lint,docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with lint,docs
 sphinx:
   fail_on_warning: false
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,9 +14,12 @@ build:
       - asdf plugin add poetry
       - asdf install poetry latest
       - asdf global poetry latest
+      - poetry config virtualenvs.create false
     post_install:
-      - poetry export --no-interaction -f requirements.txt --output requirements.txt --with lint,docs
-      - pip install -r requirements.txt
+      # - poetry export --no-interaction -f requirements.txt --output requirements.txt --with lint,docs
+      # - pip install -r requirements.txt
       # Poetry setup still seems to fail on readthedocs.
+      - poetry install --with lint,docs
 sphinx:
   fail_on_warning: false
+  configuration: docs/conf.py

--- a/mafic/__libraries.py
+++ b/mafic/__libraries.py
@@ -48,16 +48,17 @@ if not getenv("MAFIC_IGNORE_LIBRARY_CHECK"):
         raise NoCompatibleLibraries
     elif len(found) > 1:
         raise MultipleCompatibleLibraries(found)
-elif found[0] == "nextcord":
-    from warnings import simplefilter
 
-    # Ignore RuntimeWarning as we import the warning to filter :}
-    simplefilter("ignore", RuntimeWarning)
-    from nextcord.health_check import DistributionWarning
+    if found[0] == "nextcord":
+        from warnings import simplefilter
 
-    simplefilter("always", RuntimeWarning)
+        # Ignore RuntimeWarning as we import the warning to filter :}
+        simplefilter("ignore", RuntimeWarning)
+        from nextcord.health_check import DistributionWarning
 
-    simplefilter("ignore", DistributionWarning)
+        simplefilter("always", RuntimeWarning)
+
+        simplefilter("ignore", DistributionWarning)
 
 
 library = found[0]


### PR DESCRIPTION
## Summary

Fix poetry install returning "poetry: export:command not found" error. Also applies the configuration addition from #119, thanks @spifory!

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [x] I have run `task lint` to format code and my changes.
- [x] I have run `task pyright` and fixed the relevant issues.
